### PR TITLE
feat(backend): Model router - complexity scoring, 3-tier routing, cost tracking #11

### DIFF
--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -52,6 +52,7 @@ class Settings(BaseSettings):
     # Claude AI Orchestrator
     claude_default_model: str = "claude-sonnet-4-5-20250929"
     claude_simple_model: str = "claude-haiku-4-5-20251001"
+    claude_complex_model: str = "claude-opus-4-5-20250929"
     claude_max_iterations: int = 10
     claude_max_tokens: int = 4096
 

--- a/apps/backend/app/orchestrator/agent.py
+++ b/apps/backend/app/orchestrator/agent.py
@@ -9,7 +9,7 @@ import anthropic.types
 import structlog
 
 from app.core.config import get_settings
-from app.orchestrator.model_router import select_model
+from app.orchestrator.model_router import record_cost, select_model
 from app.orchestrator.prompt_builder import build_system_prompt
 from app.orchestrator.tool_registry import ToolRegistry
 from app.schemas.orchestrator import (
@@ -90,7 +90,7 @@ class OrchestratorAgent:
             MaxIterationsReachedError: If loop exceeds MAX_ITERATIONS.
             ClaudeAPIError: If Claude API returns an unrecoverable error.
         """
-        # Select model based on message content
+        # Select model based on message complexity
         router_result = select_model(request.message)
         model = router_result.model
 
@@ -98,7 +98,11 @@ class OrchestratorAgent:
             "orchestrator_model_selected",
             session_id=request.session_id,
             model=model,
+            tier=router_result.tier.value,
             reason=router_result.reason,
+            complexity_score=router_result.complexity_score,
+            is_override=router_result.is_override,
+            is_fallback=router_result.is_fallback,
         )
 
         # Build system prompt
@@ -235,13 +239,23 @@ class OrchestratorAgent:
             }
             conversation.append(final_assistant_msg)
 
+        # Record cost for this request
+        cost = record_cost(
+            tier=router_result.tier,
+            model=model,
+            input_tokens=total_input_tokens,
+            output_tokens=total_output_tokens,
+        )
+
         await logger.ainfo(
             "orchestrator_completed",
             session_id=request.session_id,
             model=model,
+            tier=router_result.tier.value,
             tokens_input=total_input_tokens,
             tokens_output=total_output_tokens,
             tool_calls_count=tool_calls_count,
+            estimated_cost_usd=cost.estimated_cost_usd,
         )
 
         return OrchestratorResponse(

--- a/apps/backend/app/orchestrator/model_router.py
+++ b/apps/backend/app/orchestrator/model_router.py
@@ -226,10 +226,10 @@ def compute_complexity_score(message: str) -> int:
     msg_len = len(message)
     if msg_len < 20:
         score -= 10  # Very short -> likely simple
-    elif msg_len > 200:
-        score += 10  # Long -> likely complex
     elif msg_len > 500:
         score += 20  # Very long -> likely very complex
+    elif msg_len > 200:
+        score += 10  # Long -> likely complex
 
     # 4. Code block detection (triple backticks)
     code_block_count = message.count("```")

--- a/apps/backend/app/orchestrator/model_router.py
+++ b/apps/backend/app/orchestrator/model_router.py
@@ -1,29 +1,116 @@
-"""Model router - selects the appropriate Claude model based on message complexity."""
+"""Model router - selects the appropriate Claude model based on message complexity.
+
+Implements a multi-tier routing system:
+- Haiku: Simple tasks (greetings, short answers, status queries)
+- Sonnet: Default / medium complexity tasks
+- Opus: Complex tasks (multi-step reasoning, code generation, architecture)
+
+Features:
+- Complexity scoring algorithm with weighted signals
+- User override mechanism (explicit model request)
+- Cost tracking per model tier
+- Fallback strategy when a model is unavailable
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
 
 import structlog
 from pydantic import BaseModel, ConfigDict
 
 logger: structlog.stdlib.BoundLogger = structlog.get_logger()
 
-# Keywords that indicate a complex task requiring Sonnet
-_COMPLEX_KEYWORDS: list[str] = [
-    "review",
-    "analiz",
-    "neden",
-    "debug",
-    "plan",
-    "oner",
-    "test sonuc",
-    "karsilastir",
-    "detayli",
-    "incele",
-    "acikla",
-    "mimari",
-    "refactor",
-    "optimize",
-]
 
-# Keywords that indicate a simple task suitable for Haiku
+class ModelTier(StrEnum):
+    """Available model tiers ordered by capability."""
+
+    HAIKU = "haiku"
+    SONNET = "sonnet"
+    OPUS = "opus"
+
+
+# Model identifiers for each tier
+MODEL_HAIKU: str = "claude-haiku-4-5-20251001"
+MODEL_SONNET: str = "claude-sonnet-4-5-20250929"
+MODEL_OPUS: str = "claude-opus-4-5-20250929"
+
+# Mapping from tier to model identifier
+_TIER_TO_MODEL: dict[ModelTier, str] = {
+    ModelTier.HAIKU: MODEL_HAIKU,
+    ModelTier.SONNET: MODEL_SONNET,
+    ModelTier.OPUS: MODEL_OPUS,
+}
+
+# Fallback chain: if requested tier is unavailable, try the next one
+_FALLBACK_CHAIN: dict[ModelTier, list[ModelTier]] = {
+    ModelTier.OPUS: [ModelTier.SONNET, ModelTier.HAIKU],
+    ModelTier.SONNET: [ModelTier.HAIKU],
+    ModelTier.HAIKU: [ModelTier.SONNET],
+}
+
+# ----- Complexity scoring configuration -----
+
+# Threshold scores for tier selection
+_HAIKU_THRESHOLD: int = 20
+_OPUS_THRESHOLD: int = 70
+# Score between HAIKU_THRESHOLD and OPUS_THRESHOLD -> Sonnet
+
+# Keywords and their complexity weights
+_KEYWORD_SCORES: dict[str, int] = {
+    # High complexity -> Opus territory (15-25 points each)
+    "mimari": 25,
+    "architecture": 25,
+    "tasarla": 20,
+    "design": 20,
+    "refactor": 20,
+    "multi-step": 20,
+    "cok adimli": 20,
+    "kod yaz": 20,
+    "code gen": 20,
+    "implement": 18,
+    "optimize": 18,
+    "karsilastir": 15,
+    "analiz et": 15,
+    "analyze": 15,
+    "debug": 15,
+    "detayli acikla": 15,
+    "explain in detail": 15,
+    "plan olustur": 15,
+    "create plan": 15,
+    "strateji": 15,
+    "strategy": 15,
+    # Medium complexity -> Sonnet territory (5-14 points each)
+    "review": 12,
+    "analiz": 10,
+    "neden": 10,
+    "plan": 10,
+    "oner": 10,
+    "test sonuc": 10,
+    "detayli": 10,
+    "incele": 10,
+    "acikla": 8,
+    "ozetle": 8,
+    "summarize": 8,
+    "cevir": 5,
+    "translate": 5,
+    # Low complexity -> Haiku territory (negative points)
+    "merhaba": -15,
+    "selam": -15,
+    "hello": -15,
+    "hi": -10,
+    "hey": -10,
+    "nasilsin": -10,
+    "tesekkur": -10,
+    "sagol": -10,
+    "tamam": -10,
+    "evet": -10,
+    "hayir": -10,
+    "ok": -8,
+}
+
+# Simple keywords that push score down
 _SIMPLE_KEYWORDS: list[str] = [
     "durum",
     "status",
@@ -38,63 +125,313 @@ _SIMPLE_KEYWORDS: list[str] = [
     "uptime",
     "saglik",
     "health",
+    "ping",
+    "version",
 ]
 
-# Default model names
-MODEL_SONNET: str = "claude-sonnet-4-5-20250929"
-MODEL_HAIKU: str = "claude-haiku-4-5-20251001"
+# Score adjustment for simple keywords
+_SIMPLE_KEYWORD_SCORE: int = -10
+
+# Override patterns: user explicitly requests a model
+_OVERRIDE_PATTERNS: dict[str, ModelTier] = {
+    r"\bhaiku\s+kullan\b": ModelTier.HAIKU,
+    r"\buse\s+haiku\b": ModelTier.HAIKU,
+    r"\bsonnet\s+kullan\b": ModelTier.SONNET,
+    r"\buse\s+sonnet\b": ModelTier.SONNET,
+    r"\bopus\s+kullan\b": ModelTier.OPUS,
+    r"\buse\s+opus\b": ModelTier.OPUS,
+    r"\bhizli\s+cevap\b": ModelTier.HAIKU,
+    r"\bquick\s+answer\b": ModelTier.HAIKU,
+    r"\ben\s+iyi\s+model\b": ModelTier.OPUS,
+    r"\bbest\s+model\b": ModelTier.OPUS,
+}
+
+# Cost per 1K tokens (approximate USD) for tracking
+_COST_PER_1K_INPUT: dict[ModelTier, float] = {
+    ModelTier.HAIKU: 0.001,
+    ModelTier.SONNET: 0.003,
+    ModelTier.OPUS: 0.015,
+}
+
+_COST_PER_1K_OUTPUT: dict[ModelTier, float] = {
+    ModelTier.HAIKU: 0.005,
+    ModelTier.SONNET: 0.015,
+    ModelTier.OPUS: 0.075,
+}
 
 
 class ModelRouterResult(BaseModel):
-    """Result of model selection."""
+    """Result of model selection with full routing metadata."""
 
     model_config = ConfigDict(frozen=True)
 
     model: str
+    tier: ModelTier
     reason: str
+    complexity_score: int
+    is_override: bool = False
+    is_fallback: bool = False
+
+
+class CostEstimate(BaseModel):
+    """Estimated cost for a model tier."""
+
+    model_config = ConfigDict(frozen=True)
+
+    tier: ModelTier
+    input_cost_per_1k: float
+    output_cost_per_1k: float
+
+
+class CostRecord(BaseModel):
+    """Recorded cost for a completed request."""
+
+    model_config = ConfigDict(frozen=True)
+
+    tier: ModelTier
+    model: str
+    input_tokens: int
+    output_tokens: int
+    estimated_cost_usd: float
+
+
+def compute_complexity_score(message: str) -> int:
+    """Compute a complexity score for the given message.
+
+    The score is a weighted sum of keyword matches, message length,
+    and structural signals (code blocks, question marks, etc.).
+
+    Higher scores indicate more complex messages.
+
+    Args:
+        message: User message text.
+
+    Returns:
+        Integer complexity score. Typical range: -20 to 100+.
+    """
+    message_lower = message.lower()
+    score = 0
+
+    # 1. Keyword scoring
+    for keyword, weight in _KEYWORD_SCORES.items():
+        if keyword in message_lower:
+            score += weight
+
+    # 2. Simple keyword scoring
+    for keyword in _SIMPLE_KEYWORDS:
+        if keyword in message_lower:
+            score += _SIMPLE_KEYWORD_SCORE
+
+    # 3. Message length signal
+    msg_len = len(message)
+    if msg_len < 20:
+        score -= 10  # Very short -> likely simple
+    elif msg_len > 200:
+        score += 10  # Long -> likely complex
+    elif msg_len > 500:
+        score += 20  # Very long -> likely very complex
+
+    # 4. Code block detection (triple backticks)
+    code_block_count = message.count("```")
+    if code_block_count >= 2:
+        score += 15  # Contains code blocks -> complex
+
+    # 5. Multiple question marks -> multi-part question
+    question_count = message.count("?")
+    if question_count >= 3:
+        score += 10
+    elif question_count >= 2:
+        score += 5
+
+    # 6. Numbered list detection (multi-step task)
+    numbered_list_pattern = re.compile(r"^\s*\d+[\.\)]\s+", re.MULTILINE)
+    numbered_items = len(numbered_list_pattern.findall(message))
+    if numbered_items >= 3:
+        score += 15  # Multi-step task
+    elif numbered_items >= 2:
+        score += 8
+
+    # Clamp score to reasonable range
+    return max(-30, min(score, 120))
+
+
+def _check_override(message: str) -> ModelTier | None:
+    """Check if the user explicitly requested a specific model.
+
+    Args:
+        message: User message text.
+
+    Returns:
+        ModelTier if an override pattern matched, None otherwise.
+    """
+    message_lower = message.lower()
+    for pattern, tier in _OVERRIDE_PATTERNS.items():
+        if re.search(pattern, message_lower):
+            return tier
+    return None
+
+
+def _tier_from_score(score: int) -> ModelTier:
+    """Map a complexity score to a model tier.
+
+    Args:
+        score: Complexity score.
+
+    Returns:
+        ModelTier based on score thresholds.
+    """
+    if score < _HAIKU_THRESHOLD:
+        return ModelTier.HAIKU
+    if score >= _OPUS_THRESHOLD:
+        return ModelTier.OPUS
+    return ModelTier.SONNET
+
+
+def get_model_for_tier(
+    tier: ModelTier,
+    *,
+    available_models: set[str] | None = None,
+) -> tuple[str, bool]:
+    """Get the model identifier for a tier with fallback support.
+
+    If the preferred model is not in available_models, walks the
+    fallback chain to find an alternative.
+
+    Args:
+        tier: Desired model tier.
+        available_models: Set of available model identifiers.
+            If None, all models are considered available.
+
+    Returns:
+        Tuple of (model_identifier, is_fallback).
+    """
+    preferred = _TIER_TO_MODEL[tier]
+
+    if available_models is None or preferred in available_models:
+        return preferred, False
+
+    # Walk the fallback chain
+    for fallback_tier in _FALLBACK_CHAIN[tier]:
+        fallback_model = _TIER_TO_MODEL[fallback_tier]
+        if fallback_model in available_models:
+            return fallback_model, True
+
+    # All fallbacks exhausted — return preferred anyway (let API handle error)
+    return preferred, False
 
 
 def select_model(
     message: str,
     *,
-    default_model: str = MODEL_SONNET,
-    simple_model: str = MODEL_HAIKU,
+    override_tier: ModelTier | None = None,
+    available_models: set[str] | None = None,
 ) -> ModelRouterResult:
-    """Select the appropriate model based on message content.
+    """Select the appropriate Claude model based on message complexity.
 
-    Uses keyword-based heuristics to determine complexity:
-    - Complex keywords -> Sonnet (deeper reasoning)
-    - Simple keywords -> Haiku (fast, cheap)
-    - Default -> Sonnet (safe fallback)
+    Routing logic (in priority order):
+    1. Explicit override_tier parameter
+    2. User override pattern in message text
+    3. Complexity score-based tier selection
 
     Args:
         message: User message text.
-        default_model: Model to use for complex/default tasks.
-        simple_model: Model to use for simple tasks.
+        override_tier: Force a specific tier (e.g., from user preference).
+        available_models: Set of available model IDs for fallback logic.
 
     Returns:
-        ModelRouterResult with selected model and reason.
+        ModelRouterResult with selected model, tier, score, and metadata.
     """
-    message_lower = message.lower()
+    complexity_score = compute_complexity_score(message)
 
-    # Check for complex keywords first (higher priority)
-    for keyword in _COMPLEX_KEYWORDS:
-        if keyword in message_lower:
-            return ModelRouterResult(
-                model=default_model,
-                reason=f"complex_keyword:{keyword}",
-            )
+    # Priority 1: Explicit override_tier parameter
+    if override_tier is not None:
+        model, is_fallback = get_model_for_tier(override_tier, available_models=available_models)
+        return ModelRouterResult(
+            model=model,
+            tier=override_tier,
+            reason=f"explicit_override:{override_tier.value}",
+            complexity_score=complexity_score,
+            is_override=True,
+            is_fallback=is_fallback,
+        )
 
-    # Check for simple keywords
-    for keyword in _SIMPLE_KEYWORDS:
-        if keyword in message_lower:
-            return ModelRouterResult(
-                model=simple_model,
-                reason=f"simple_keyword:{keyword}",
-            )
+    # Priority 2: User override pattern in message
+    user_override = _check_override(message)
+    if user_override is not None:
+        model, is_fallback = get_model_for_tier(user_override, available_models=available_models)
+        return ModelRouterResult(
+            model=model,
+            tier=user_override,
+            reason=f"user_override:{user_override.value}",
+            complexity_score=complexity_score,
+            is_override=True,
+            is_fallback=is_fallback,
+        )
 
-    # Default: use the more capable model
+    # Priority 3: Complexity score-based selection
+    tier = _tier_from_score(complexity_score)
+    model, is_fallback = get_model_for_tier(tier, available_models=available_models)
+
+    # Determine reason string
+    if tier == ModelTier.HAIKU:
+        reason = "complexity_score:simple"
+    elif tier == ModelTier.OPUS:
+        reason = "complexity_score:complex"
+    else:
+        reason = "complexity_score:medium"
+
     return ModelRouterResult(
-        model=default_model,
-        reason="default_fallback",
+        model=model,
+        tier=tier,
+        reason=reason,
+        complexity_score=complexity_score,
+        is_override=False,
+        is_fallback=is_fallback,
+    )
+
+
+def estimate_cost(tier: ModelTier) -> CostEstimate:
+    """Get estimated cost per 1K tokens for a model tier.
+
+    Args:
+        tier: Model tier.
+
+    Returns:
+        CostEstimate with input and output costs.
+    """
+    return CostEstimate(
+        tier=tier,
+        input_cost_per_1k=_COST_PER_1K_INPUT[tier],
+        output_cost_per_1k=_COST_PER_1K_OUTPUT[tier],
+    )
+
+
+def record_cost(
+    *,
+    tier: ModelTier,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+) -> CostRecord:
+    """Record and calculate the cost for a completed request.
+
+    Args:
+        tier: Model tier used.
+        model: Model identifier used.
+        input_tokens: Number of input tokens consumed.
+        output_tokens: Number of output tokens consumed.
+
+    Returns:
+        CostRecord with calculated estimated cost.
+    """
+    input_cost = (input_tokens / 1000) * _COST_PER_1K_INPUT[tier]
+    output_cost = (output_tokens / 1000) * _COST_PER_1K_OUTPUT[tier]
+    total_cost = round(input_cost + output_cost, 6)
+
+    return CostRecord(
+        tier=tier,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        estimated_cost_usd=total_cost,
     )

--- a/apps/backend/tests/unit/test_orchestrator/test_model_router.py
+++ b/apps/backend/tests/unit/test_orchestrator/test_model_router.py
@@ -332,6 +332,137 @@ class TestCostTracking:
         assert was_frozen
 
 
+class TestComputeComplexityScoreEdgeCases:
+    """Additional edge case tests for complexity score computation."""
+
+    def test_very_long_message_over_500_chars(self) -> None:
+        """Messages over 500 chars should get the +20 score boost."""
+        very_long = "x " * 260  # 520 chars, no keywords
+        score = compute_complexity_score(very_long)
+        # +20 for length, no keywords
+        assert score >= 10
+
+    def test_two_question_marks(self) -> None:
+        """Exactly 2 question marks should give +5 score."""
+        msg = "Bunu yapar misin? Ve bunu da?"
+        score_two_q = compute_complexity_score(msg)
+        msg_one = "Bunu yapar misin"
+        score_one_q = compute_complexity_score(msg_one)
+        assert score_two_q > score_one_q
+
+    def test_two_numbered_items(self) -> None:
+        """Exactly 2 numbered items should give +8 score."""
+        msg = "Su iki seyi yap:\n1. Dosyayi oku\n2. Guncelle"
+        score = compute_complexity_score(msg)
+        msg_no_list = "Su iki seyi yap: Dosyayi oku ve guncelle"
+        score_no_list = compute_complexity_score(msg_no_list)
+        assert score > score_no_list
+
+    def test_medium_length_message_no_boost(self) -> None:
+        """Messages between 20 and 200 chars should get no length boost."""
+        msg = "Bu bir orta uzunlukta mesaj"  # ~27 chars
+        score = compute_complexity_score(msg)
+        # No length bonus, but also no penalty for being short
+        assert isinstance(score, int)
+
+    def test_single_code_block_no_boost(self) -> None:
+        """A single backtick (not a full code block pair) should not boost."""
+        msg = "Bunu yap: ```python code"  # only 1 triple backtick
+        score_single = compute_complexity_score(msg)
+        msg_none = "Bunu yap: python code"
+        score_none = compute_complexity_score(msg_none)
+        # Single triple backtick (count=1, < 2) should not add +15
+        assert score_single == score_none
+
+    def test_parenthesis_numbered_list(self) -> None:
+        """Numbered lists with parenthesis format should be detected."""
+        msg = "Adimlar:\n1) Oku\n2) Yaz\n3) Kaydet"
+        score = compute_complexity_score(msg)
+        assert score > 0  # Should detect 3 numbered items
+
+    def test_no_override_match(self) -> None:
+        """Messages without override patterns should not trigger override."""
+        result = select_model("Bu normal bir mesaj, analiz et detayli")
+        assert result.is_override is False
+
+    def test_multiple_override_patterns_first_wins(self) -> None:
+        """If message contains multiple override patterns, first match wins."""
+        result = select_model("haiku kullan ama en iyi model de olabilir")
+        # 'haiku kullan' should match first
+        assert result.is_override is True
+
+    def test_select_model_with_opus_score_returns_opus_reason(self) -> None:
+        """High scoring messages should have 'complexity_score:complex' reason."""
+        result = select_model(
+            "Mimari tasarla, multi-step refactor planla ve implement stratejisi belirle"
+        )
+        assert result.reason == "complexity_score:complex"
+
+    def test_select_model_with_haiku_score_returns_simple_reason(self) -> None:
+        """Low scoring messages should have 'complexity_score:simple' reason."""
+        result = select_model("merhaba")
+        assert result.reason == "complexity_score:simple"
+
+    def test_select_model_with_sonnet_score_returns_medium_reason(self) -> None:
+        """Medium scoring messages should have 'complexity_score:medium' reason."""
+        result = select_model("Bu kodu detayli analiz et ve sonuclari raporla")
+        assert result.reason == "complexity_score:medium"
+
+
+class TestCostTrackingEdgeCases:
+    """Additional tests for cost tracking edge cases."""
+
+    def test_estimate_cost_sonnet(self) -> None:
+        """Sonnet cost estimate should be returned correctly."""
+        est = estimate_cost(ModelTier.SONNET)
+        assert isinstance(est, CostEstimate)
+        assert est.tier == ModelTier.SONNET
+
+    def test_estimate_cost_opus(self) -> None:
+        """Opus cost estimate should be returned correctly."""
+        est = estimate_cost(ModelTier.OPUS)
+        assert isinstance(est, CostEstimate)
+        assert est.tier == ModelTier.OPUS
+
+    def test_record_cost_precise_calculation(self) -> None:
+        """record_cost should calculate precise USD cost."""
+        # Haiku: input=0.001/1K, output=0.005/1K
+        cost = record_cost(
+            tier=ModelTier.HAIKU,
+            model=MODEL_HAIKU,
+            input_tokens=2000,
+            output_tokens=1000,
+        )
+        # Expected: (2000/1000 * 0.001) + (1000/1000 * 0.005) = 0.002 + 0.005 = 0.007
+        assert cost.estimated_cost_usd == 0.007
+
+    def test_record_cost_opus_higher_than_haiku(self) -> None:
+        """Same token count with Opus should cost more than Haiku."""
+        cost_haiku = record_cost(
+            tier=ModelTier.HAIKU,
+            model=MODEL_HAIKU,
+            input_tokens=1000,
+            output_tokens=1000,
+        )
+        cost_opus = record_cost(
+            tier=ModelTier.OPUS,
+            model=MODEL_OPUS,
+            input_tokens=1000,
+            output_tokens=1000,
+        )
+        assert cost_opus.estimated_cost_usd > cost_haiku.estimated_cost_usd
+
+    def test_cost_estimate_frozen(self) -> None:
+        """CostEstimate should be immutable."""
+        est = estimate_cost(ModelTier.HAIKU)
+        try:
+            est.input_cost_per_1k = 999.0  # type: ignore[misc]
+            was_frozen = False
+        except Exception:
+            was_frozen = True
+        assert was_frozen
+
+
 class TestModelTier:
     """Tests for the ModelTier enum."""
 

--- a/apps/backend/tests/unit/test_orchestrator/test_model_router.py
+++ b/apps/backend/tests/unit/test_orchestrator/test_model_router.py
@@ -2,85 +2,167 @@
 
 from app.orchestrator.model_router import (
     MODEL_HAIKU,
+    MODEL_OPUS,
     MODEL_SONNET,
+    CostEstimate,
+    CostRecord,
     ModelRouterResult,
+    ModelTier,
+    compute_complexity_score,
+    estimate_cost,
+    get_model_for_tier,
+    record_cost,
     select_model,
 )
+
+
+class TestComputeComplexityScore:
+    """Tests for the compute_complexity_score function."""
+
+    def test_simple_greeting_returns_low_score(self) -> None:
+        """Simple greetings should produce negative/low scores."""
+        score = compute_complexity_score("merhaba")
+        assert score < 20
+
+    def test_complex_architecture_question_returns_high_score(self) -> None:
+        """Architecture-level questions should produce high scores."""
+        score = compute_complexity_score(
+            "Bu projenin mimari yapisini tasarla ve multi-step bir plan olustur"
+        )
+        assert score >= 70
+
+    def test_medium_analysis_request_returns_medium_score(self) -> None:
+        """Medium complexity requests should return medium scores."""
+        score = compute_complexity_score("Bu kodu detayli analiz et")
+        assert 20 <= score < 70
+
+    def test_short_message_reduces_score(self) -> None:
+        """Very short messages should reduce the score."""
+        score = compute_complexity_score("test")
+        assert score < 20
+
+    def test_long_message_increases_score(self) -> None:
+        """Long messages (>200 chars) should increase the score."""
+        long_msg = "a " * 120  # 240 chars
+        score = compute_complexity_score(long_msg)
+        # Should get +10 for length
+        assert score >= 0
+
+    def test_code_blocks_increase_score(self) -> None:
+        """Messages with code blocks should get a score boost."""
+        msg = "Bunu duzelt:\n```python\ndef foo():\n    pass\n```"
+        score_with_code = compute_complexity_score(msg)
+        score_without_code = compute_complexity_score("Bunu duzelt: def foo(): pass")
+        assert score_with_code > score_without_code
+
+    def test_multiple_questions_increase_score(self) -> None:
+        """Multiple question marks indicate a multi-part question."""
+        msg = "Neden boyle? Nasil calisir? Ne yapmaliyiz?"
+        score = compute_complexity_score(msg)
+        # 3 question marks -> +10, plus 'neden' keyword -> +10
+        assert score > 0
+
+    def test_numbered_list_increases_score(self) -> None:
+        """Numbered lists indicate multi-step tasks -> higher score."""
+        msg = "Su adimlari yap:\n1. Dosyayi oku\n2. Analiz et\n3. Raporla"
+        score = compute_complexity_score(msg)
+        assert score > 0
+
+    def test_score_clamped_to_range(self) -> None:
+        """Score should be clamped between -30 and 120."""
+        # Very simple message
+        score_low = compute_complexity_score("merhaba selam nasilsin tesekkur sagol tamam evet")
+        assert score_low >= -30
+
+        # Very complex message
+        msg = "mimari tasarla refactor optimize multi-step cok adimli kod yaz implement " * 5
+        score_high = compute_complexity_score(msg)
+        assert score_high <= 120
+
+    def test_empty_message_returns_low_score(self) -> None:
+        """Empty message should return a low score."""
+        score = compute_complexity_score("")
+        assert score < 20
+
+    def test_simple_keywords_reduce_score(self) -> None:
+        """Simple keywords (status, log, etc.) should reduce the score."""
+        score = compute_complexity_score("status goster")
+        assert score < 20
 
 
 class TestSelectModel:
     """Tests for the select_model function."""
 
-    def test_complex_keyword_returns_sonnet(self) -> None:
-        """Complex keywords should select the Sonnet model."""
-        result = select_model("Bu kodu analiz et")
-        assert result.model == MODEL_SONNET
-        assert "complex_keyword" in result.reason
-
-    def test_simple_keyword_returns_haiku(self) -> None:
-        """Simple keywords should select the Haiku model."""
-        result = select_model("Proje durumunu goster")
+    def test_simple_message_returns_haiku(self) -> None:
+        """Simple messages should select Haiku."""
+        result = select_model("merhaba, selam")
         assert result.model == MODEL_HAIKU
-        assert "simple_keyword" in result.reason
+        assert result.tier == ModelTier.HAIKU
 
-    def test_default_returns_sonnet(self) -> None:
-        """Messages without matching keywords should default to Sonnet."""
-        result = select_model("Merhaba, nasilsin?")
-        assert result.model == MODEL_SONNET
-        assert result.reason == "default_fallback"
-
-    def test_complex_keywords_all_match(self) -> None:
-        """All complex keywords should be recognized."""
-        complex_keywords = [
-            "review", "analiz", "neden", "debug", "plan",
-            "oner", "test sonuc", "karsilastir", "detayli",
-            "incele", "acikla", "mimari", "refactor", "optimize",
-        ]
-        for keyword in complex_keywords:
-            result = select_model(f"Lutfen {keyword} yap")
-            assert result.model == MODEL_SONNET, f"Failed for keyword: {keyword}"
-
-    def test_simple_keywords_all_match(self) -> None:
-        """All simple keywords should be recognized."""
-        simple_keywords = [
-            "durum", "status", "log", "start", "stop",
-            "restart", "list", "listele", "kac", "ne zaman",
-            "uptime", "saglik", "health",
-        ]
-        for keyword in simple_keywords:
-            result = select_model(f"Proje {keyword}")
-            assert result.model == MODEL_HAIKU, f"Failed for keyword: {keyword}"
-
-    def test_case_insensitive(self) -> None:
-        """Keyword matching should be case-insensitive."""
-        result = select_model("Bu kodu ANALIZ et")
+    def test_medium_message_returns_sonnet(self) -> None:
+        """Medium complexity messages should select Sonnet."""
+        result = select_model("Bu kodu detayli analiz et ve sonuclari raporla")
+        assert result.tier == ModelTier.SONNET
         assert result.model == MODEL_SONNET
 
-    def test_complex_overrides_simple(self) -> None:
-        """Complex keywords should take priority over simple keywords."""
-        result = select_model("Projenin durumunu detayli analiz et")
-        assert result.model == MODEL_SONNET
-        assert "complex_keyword" in result.reason
-
-    def test_custom_models(self) -> None:
-        """Custom model names should be used when provided."""
+    def test_complex_message_returns_opus(self) -> None:
+        """Complex multi-step messages should select Opus."""
         result = select_model(
-            "log goster",
-            default_model="custom-sonnet",
-            simple_model="custom-haiku",
+            "Projenin mimari yapisini tasarla, multi-step bir refactor plani olustur "
+            "ve implement stratejisi belirle"
         )
-        assert result.model == "custom-haiku"
+        assert result.tier == ModelTier.OPUS
+        assert result.model == MODEL_OPUS
+
+    def test_override_tier_parameter(self) -> None:
+        """Explicit override_tier should bypass scoring."""
+        # Even a simple message should use Opus with override
+        result = select_model("merhaba", override_tier=ModelTier.OPUS)
+        assert result.model == MODEL_OPUS
+        assert result.tier == ModelTier.OPUS
+        assert result.is_override is True
+        assert "explicit_override" in result.reason
+
+    def test_user_override_haiku_kullan(self) -> None:
+        """User saying 'haiku kullan' should trigger override."""
+        result = select_model("haiku kullan ve bana durumu goster")
+        assert result.tier == ModelTier.HAIKU
+        assert result.is_override is True
+        assert "user_override" in result.reason
+
+    def test_user_override_opus_kullan(self) -> None:
+        """User saying 'opus kullan' should trigger override."""
+        result = select_model("opus kullan ve kodu analiz et")
+        assert result.tier == ModelTier.OPUS
+        assert result.is_override is True
+
+    def test_user_override_use_sonnet(self) -> None:
+        """User saying 'use sonnet' should trigger override."""
+        result = select_model("use sonnet for this task")
+        assert result.tier == ModelTier.SONNET
+        assert result.is_override is True
+
+    def test_user_override_best_model(self) -> None:
+        """User saying 'en iyi model' should select Opus."""
+        result = select_model("en iyi model ile cevapla")
+        assert result.tier == ModelTier.OPUS
+        assert result.is_override is True
+
+    def test_user_override_quick_answer(self) -> None:
+        """User saying 'hizli cevap' should select Haiku."""
+        result = select_model("hizli cevap ver")
+        assert result.tier == ModelTier.HAIKU
+        assert result.is_override is True
+
+    def test_result_contains_complexity_score(self) -> None:
+        """Result should contain the computed complexity score."""
+        result = select_model("test mesaji")
+        assert isinstance(result.complexity_score, int)
 
     def test_returns_model_router_result(self) -> None:
         """Function should return a ModelRouterResult instance."""
         result = select_model("test mesaji")
         assert isinstance(result, ModelRouterResult)
-
-    def test_empty_message_returns_default(self) -> None:
-        """Empty message should return default model."""
-        result = select_model("")
-        assert result.model == MODEL_SONNET
-        assert result.reason == "default_fallback"
 
     def test_result_is_frozen(self) -> None:
         """ModelRouterResult should be immutable (frozen)."""
@@ -91,3 +173,175 @@ class TestSelectModel:
         except Exception:
             was_frozen = True
         assert was_frozen, "ModelRouterResult should be frozen"
+
+    def test_case_insensitive(self) -> None:
+        """Keyword matching should be case-insensitive."""
+        result1 = select_model("MIMARI tasarla ve REFACTOR planla")
+        result2 = select_model("mimari tasarla ve refactor planla")
+        assert result1.complexity_score == result2.complexity_score
+
+    def test_default_is_not_override(self) -> None:
+        """Normal score-based selection should not be flagged as override."""
+        result = select_model("Bu projeyi incele")
+        assert result.is_override is False
+
+    def test_status_query_returns_haiku(self) -> None:
+        """Status queries (simple keyword) should select Haiku."""
+        result = select_model("durum nedir")
+        assert result.tier == ModelTier.HAIKU
+
+    def test_all_simple_keywords_route_to_haiku(self) -> None:
+        """All simple keywords should produce low enough scores for Haiku."""
+        simple_keywords = [
+            "durum",
+            "status",
+            "log",
+            "start",
+            "stop",
+            "restart",
+            "listele",
+            "health",
+        ]
+        for keyword in simple_keywords:
+            result = select_model(keyword)
+            assert result.tier == ModelTier.HAIKU, f"Failed for keyword: {keyword}"
+
+
+class TestGetModelForTier:
+    """Tests for the get_model_for_tier function."""
+
+    def test_returns_preferred_model_when_available(self) -> None:
+        """Should return the preferred model when all are available."""
+        model, is_fallback = get_model_for_tier(ModelTier.SONNET)
+        assert model == MODEL_SONNET
+        assert is_fallback is False
+
+    def test_returns_preferred_when_no_availability_set(self) -> None:
+        """Should return the preferred model when available_models is None."""
+        model, is_fallback = get_model_for_tier(ModelTier.OPUS)
+        assert model == MODEL_OPUS
+        assert is_fallback is False
+
+    def test_falls_back_when_preferred_unavailable(self) -> None:
+        """Should use fallback when preferred model is unavailable."""
+        available = {MODEL_SONNET, MODEL_HAIKU}
+        model, is_fallback = get_model_for_tier(
+            ModelTier.OPUS, available_models=available
+        )
+        assert model == MODEL_SONNET
+        assert is_fallback is True
+
+    def test_haiku_falls_back_to_sonnet(self) -> None:
+        """Haiku should fall back to Sonnet when unavailable."""
+        available = {MODEL_SONNET, MODEL_OPUS}
+        model, is_fallback = get_model_for_tier(
+            ModelTier.HAIKU, available_models=available
+        )
+        assert model == MODEL_SONNET
+        assert is_fallback is True
+
+    def test_sonnet_falls_back_to_haiku(self) -> None:
+        """Sonnet should fall back to Haiku when unavailable."""
+        available = {MODEL_HAIKU}
+        model, is_fallback = get_model_for_tier(
+            ModelTier.SONNET, available_models=available
+        )
+        assert model == MODEL_HAIKU
+        assert is_fallback is True
+
+    def test_returns_preferred_when_all_unavailable(self) -> None:
+        """Should return preferred model when no fallbacks match."""
+        model, is_fallback = get_model_for_tier(
+            ModelTier.OPUS, available_models=set()
+        )
+        assert model == MODEL_OPUS
+        assert is_fallback is False
+
+    def test_fallback_flag_in_select_model(self) -> None:
+        """select_model should propagate fallback flag."""
+        result = select_model(
+            "merhaba",
+            available_models={MODEL_SONNET},
+        )
+        # Haiku preferred for simple message, but not available
+        if result.model != MODEL_HAIKU:
+            assert result.is_fallback is True
+
+
+class TestCostTracking:
+    """Tests for cost estimation and recording functions."""
+
+    def test_estimate_cost_haiku(self) -> None:
+        """Haiku cost estimate should reflect cheapest tier."""
+        est = estimate_cost(ModelTier.HAIKU)
+        assert isinstance(est, CostEstimate)
+        assert est.tier == ModelTier.HAIKU
+        assert est.input_cost_per_1k > 0
+        assert est.output_cost_per_1k > 0
+        assert est.input_cost_per_1k <= estimate_cost(ModelTier.SONNET).input_cost_per_1k
+
+    def test_estimate_cost_ordering(self) -> None:
+        """Cost should increase from Haiku < Sonnet < Opus."""
+        haiku = estimate_cost(ModelTier.HAIKU)
+        sonnet = estimate_cost(ModelTier.SONNET)
+        opus = estimate_cost(ModelTier.OPUS)
+
+        assert haiku.input_cost_per_1k < sonnet.input_cost_per_1k
+        assert sonnet.input_cost_per_1k < opus.input_cost_per_1k
+        assert haiku.output_cost_per_1k < sonnet.output_cost_per_1k
+        assert sonnet.output_cost_per_1k < opus.output_cost_per_1k
+
+    def test_record_cost_calculation(self) -> None:
+        """record_cost should correctly calculate estimated USD cost."""
+        cost = record_cost(
+            tier=ModelTier.SONNET,
+            model=MODEL_SONNET,
+            input_tokens=1000,
+            output_tokens=500,
+        )
+        assert isinstance(cost, CostRecord)
+        assert cost.tier == ModelTier.SONNET
+        assert cost.model == MODEL_SONNET
+        assert cost.input_tokens == 1000
+        assert cost.output_tokens == 500
+        assert cost.estimated_cost_usd > 0
+
+    def test_record_cost_zero_tokens(self) -> None:
+        """Zero tokens should result in zero cost."""
+        cost = record_cost(
+            tier=ModelTier.HAIKU,
+            model=MODEL_HAIKU,
+            input_tokens=0,
+            output_tokens=0,
+        )
+        assert cost.estimated_cost_usd == 0.0
+
+    def test_record_cost_frozen(self) -> None:
+        """CostRecord should be immutable."""
+        cost = record_cost(
+            tier=ModelTier.OPUS,
+            model=MODEL_OPUS,
+            input_tokens=100,
+            output_tokens=50,
+        )
+        try:
+            cost.estimated_cost_usd = 999.0  # type: ignore[misc]
+            was_frozen = False
+        except Exception:
+            was_frozen = True
+        assert was_frozen
+
+
+class TestModelTier:
+    """Tests for the ModelTier enum."""
+
+    def test_tier_values(self) -> None:
+        """ModelTier should have haiku, sonnet, opus values."""
+        assert ModelTier.HAIKU.value == "haiku"
+        assert ModelTier.SONNET.value == "sonnet"
+        assert ModelTier.OPUS.value == "opus"
+
+    def test_tier_is_string_enum(self) -> None:
+        """ModelTier should be usable as a string."""
+        assert str(ModelTier.HAIKU) == "haiku"
+        assert f"{ModelTier.SONNET}" == "sonnet"

--- a/docs/pipeline/f1/model-router-haiku-sonnet-selection-developer.handoff.md
+++ b/docs/pipeline/f1/model-router-haiku-sonnet-selection-developer.handoff.md
@@ -1,0 +1,67 @@
+# Developer Handoff: Model Router (Haiku/Sonnet/Opus Selection)
+
+**Issue**: #11
+**Branch**: feature/f1/11-model-router-haiku-sonnet-selection
+**Tarih**: 2026-03-02
+**Sonraki Agent**: tester
+
+## Yapilan Degisiklikler
+
+| Dosya | Islem | Aciklama |
+|-------|-------|----------|
+| `apps/backend/app/orchestrator/model_router.py` | MODIFY | Complexity scoring algoritması, 3-tier routing (Haiku/Sonnet/Opus), override mekanizmasi, fallback stratejisi, cost tracking eklendi |
+| `apps/backend/app/orchestrator/agent.py` | MODIFY | Cost tracking entegrasyonu, routing metadata loglama eklendi |
+| `apps/backend/app/core/config.py` | MODIFY | `claude_complex_model` (Opus) config ayari eklendi |
+| `apps/backend/tests/unit/test_orchestrator/test_model_router.py` | MODIFY | 41 yeni test: complexity scoring, tier selection, override, fallback, cost tracking |
+| `docs/pipeline/f1/model-router-haiku-sonnet-selection-developer.handoff.md` | CREATE | Bu dosya |
+
+## Implementasyon Detaylari
+
+### Complexity Scoring Algoritmasi
+- Keyword-based weighted scoring sistemi (her keyword'un agirlik puani var)
+- Mesaj uzunlugu sinyali (kisa mesajlar: -10, uzun mesajlar: +10/+20)
+- Kod blogu tespiti (triple backtick): +15
+- Coklu soru isareti tespiti: +5/+10
+- Numarali liste tespiti (multi-step task): +8/+15
+- Skor araligu: -30 ile 120 arasi clamp edilir
+
+### 3-Tier Model Routing
+- **Haiku** (score < 20): Basit selamlasma, durum sorgulari, kisa cevaplar
+- **Sonnet** (20 <= score < 70): Orta karmasiklik, analiz, review, ozet
+- **Opus** (score >= 70): Mimari tasarim, multi-step planlama, kod uretimi, refactor
+
+### Override Mekanizmasi
+1. **Explicit override_tier parametresi**: Programatik olarak tier belirleme
+2. **Kullanici mesaj kaliplari**: "haiku kullan", "opus kullan", "use sonnet", "en iyi model", "hizli cevap" gibi ifadeler
+
+### Fallback Stratejisi
+- Opus kullanilamazsa: Sonnet -> Haiku
+- Sonnet kullanilamazsa: Haiku
+- Haiku kullanilamazsa: Sonnet
+- `available_models` parametresi ile runtime'da kullanilabilir modeller belirlenebilir
+
+### Cost Tracking
+- Her tier icin 1K token basina input/output maliyet tanimlari
+- `estimate_cost()`: Tier icin tahmini maliyet bilgisi
+- `record_cost()`: Tamamlanan istek icin hesaplanmis maliyet kaydı
+- Agent'da her istek sonrasi cost loglama entegrasyonu
+
+## API Kontrat Uyumu
+- Bu feature yeni REST/WS endpoint eklemiyor, mevcut WebSocket akisindaki model secim logigini genisletiyor
+- Kontrat dosyalari etkilenmiyor
+
+## Dogrulama Sonuclari
+
+| Arac | Durum | Detay |
+|------|-------|-------|
+| ruff check | PASS | 0 hata |
+| ruff format | PASS | Formatli |
+| mypy | PASS | 40 dosya, 0 hata |
+| pytest | PASS | 295/307 passed (12 pre-existing auth failures) |
+
+## Notlar
+
+- `ModelRouterResult` artik `tier`, `complexity_score`, `is_override`, `is_fallback` alanlari iceriyor
+- Eski `default_model` ve `simple_model` parametreleri kaldirildi, tier-based routing tercih ediliyor
+- Pre-existing 12 test failure bcrypt/passlib iliskili, bu PR ile alakasiz
+- Tester icin: Tum yeni fonksiyonlar (compute_complexity_score, select_model, get_model_for_tier, estimate_cost, record_cost) test edilmeli

--- a/docs/pipeline/f1/model-router-haiku-sonnet-selection-tester.handoff.md
+++ b/docs/pipeline/f1/model-router-haiku-sonnet-selection-tester.handoff.md
@@ -1,0 +1,62 @@
+# Tester Handoff: Model Router (Haiku/Sonnet/Opus Selection)
+
+**Issue**: #11
+**Branch**: feature/f1/11-model-router-haiku-sonnet-selection
+**Tarih**: 2026-03-02
+**Sonraki Agent**: NONE (standard pipeline)
+
+## Coverage Raporu
+
+| Platform | Coverage % | Esik | Durum |
+|----------|-----------|------|-------|
+| Backend (app/) | 91% | >= 80% | PASS |
+
+### Model Router Modulu
+| Modul | Coverage % |
+|-------|-----------|
+| app/orchestrator/model_router.py | 100% |
+
+## Yazilan Testler
+
+### Backend
+| Test Dosyasi | Test Sayisi | Basarili | Basarisiz |
+|-------------|-------------|----------|-----------|
+| tests/unit/test_orchestrator/test_model_router.py | 57 | 57 | 0 |
+
+### Test Kategorileri
+
+| Kategori | Test Sayisi | Aciklama |
+|----------|------------|----------|
+| TestComputeComplexityScore | 11 | Temel complexity scoring testleri |
+| TestSelectModel | 16 | Model secim algoritmasi testleri |
+| TestGetModelForTier | 7 | Fallback mekanizmasi testleri |
+| TestCostTracking | 5 | Maliyet tahmini ve kayit testleri |
+| TestComputeComplexityScoreEdgeCases | 11 | Edge case: uzun mesaj, 2 soru isareti, 2 numarali madde, tek code block vb. |
+| TestCostTrackingEdgeCases | 5 | Precise maliyet hesaplama, tier karsilastirma |
+| TestModelTier | 2 | Enum deger ve tip testleri |
+
+## Mock Kullanimi
+
+| Mock | Neden |
+|------|-------|
+| Yok | Bu modul dis bagimliligi olmayan pure Python logik iceriyor, mock gerekmedi |
+
+## Bulunan ve Duzeltilen Sorunlar
+
+1. **elif siralama hatasi**: `msg_len > 200` branch'i `msg_len > 500` branch'inden once geliyordu, bu 500+ branch'in asla calismamasi demekti. Duzeltildi: 500 kontrolu once yapiliyor.
+
+## Edge Case'ler
+
+- Bos mesaj -> Haiku (skor < 20)
+- 500+ karakter mesaj -> +20 skor boostu
+- Tam 2 soru isareti -> +5 (3+ icin +10)
+- Tam 2 numarali madde -> +8 (3+ icin +15)
+- Tek backtick (code block degil) -> skor etkisi yok
+- Parentezli numarali listeler (1), 2)) -> tespit ediliyor
+- Birden fazla override pattern -> ilk eslesen kazanir
+- Tum modeller kullanilamazsa -> tercih edilen model donduruluyor (API hata yonetsin)
+
+## Bilinen Sorunlar
+
+- 12 pre-existing test failure: bcrypt/passlib uyumsuzlugu (auth modulu). Bu PR ile alakasiz.
+- Keyword skorlama heuristik tabanli; ML-based yaklasimlara gecis gelecekte dusunulebilir.


### PR DESCRIPTION
## Ozet
Mesaj karmasikligina gore otomatik model secimi. Basit sorular icin Haiku, orta isler icin Sonnet, karmasik isler icin Opus.

## Degisiklikler
- **Complexity scoring algoritmasi**: Keyword agirlik puanlama, mesaj uzunlugu, kod blogu, soru isareti, numarali liste tespiti
- **3-tier routing**: Haiku (score < 20), Sonnet (20-69), Opus (70+)
- **Override mekanizmasi**: Kullanici "haiku kullan", "opus kullan", "en iyi model" gibi ifadelerle model secebilir
- **Fallback stratejisi**: Model kullanilamazsa alternatif secim (Opus -> Sonnet -> Haiku)
- **Cost tracking**: Tier bazli maliyet tahmini ve kayit, her istek sonrasi loglama
- **Config**: claude_complex_model (Opus) ayari eklendi

## Pipeline
| Adim | Agent | Durum |
|------|-------|-------|
| Architect | architect | SKIPPED |
| Developer | developer | DONE |
| Tester | tester | DONE |
| Reviewer | reviewer | SKIPPED |

## Coverage
| Platform | Coverage | Esik | Durum |
|----------|----------|------|-------|
| Backend | 91% | 80% | PASS |

### Model Router Modul Coverage
| Modul | Coverage |
|-------|----------|
| model_router.py | 100% |

## Test Ozeti
- 57 unit test (tumu gecti)
- Complexity scoring, tier selection, override, fallback, cost tracking
- Edge case'ler: 500+ char, 2/3 soru isareti, 2/3 numarali madde, parentezli listeler

## Handoff Dosyalari
- docs/pipeline/f1/model-router-haiku-sonnet-selection-developer.handoff.md
- docs/pipeline/f1/model-router-haiku-sonnet-selection-tester.handoff.md

---
Generated by RafRaf AI Pipeline