### PR TITLE
infra: self-hosted rafraf-runner kullan

### DIFF
--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -22,7 +22,7 @@ defaults:
 jobs:
   lint:
     name: Lint (Ruff)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rafraf-runner]
     steps:
       - uses: actions/checkout@v4
 
@@ -44,7 +44,7 @@ jobs:
 
   typecheck:
     name: Type Check (MyPy)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rafraf-runner]
     steps:
       - uses: actions/checkout@v4
 
@@ -63,7 +63,7 @@ jobs:
 
   test:
     name: Test (Pytest)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rafraf-runner]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   auto-merge:
     name: Auto Merge
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rafraf-runner]
     if: >-
       github.event_name == 'workflow_run' ||
       (github.event_name == 'pull_request' &&

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -22,7 +22,7 @@ defaults:
 jobs:
   lint:
     name: Lint (Ruff)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rafraf-runner]
     steps:
       - uses: actions/checkout@v4
 
@@ -44,7 +44,7 @@ jobs:
 
   typecheck:
     name: Type Check (MyPy)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rafraf-runner]
     steps:
       - uses: actions/checkout@v4
 
@@ -63,7 +63,7 @@ jobs:
 
   test:
     name: Test (Pytest)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rafraf-runner]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rafraf-runner]
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       ios: ${{ steps.filter.outputs.ios }}
@@ -34,7 +34,7 @@ jobs:
     name: Backend Gate
     needs: changes
     if: needs.changes.outputs.backend == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rafraf-runner]
     timeout-minutes: 10
     defaults:
       run:
@@ -143,7 +143,7 @@ jobs:
     name: Agent Gate
     needs: changes
     if: needs.changes.outputs.agent == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rafraf-runner]
     defaults:
       run:
         working-directory: apps/agent
@@ -174,7 +174,7 @@ jobs:
 
   gate-result:
     name: PR Gate Result
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, rafraf-runner]
     needs: [changes, backend-gate, ios-gate, agent-gate]
     if: always()
     steps:


### PR DESCRIPTION
## Summary
- Tüm ubuntu-based CI job'larını `self-hosted rafraf-runner`'a taşıdık
- iOS workflow'ları `macos-15`'te kaldı (Xcode/Simulator gereksinimi)
- Etkilenen workflow'lar: `backend-ci`, `agent-ci`, `pr-gate`, `auto-merge`

## Test plan
- [ ] PR Gate workflow'u `rafraf-runner` üzerinde başarıyla çalışsın
- [ ] Runner'ın Python 3.12 setup'ı sorunsuz olsun
- [ ] Job'lar queue'da takılmadan runner'a assign olsun

🤖 Generated with [Claude Code](https://claude.com/claude-code)