### PR TITLE
feat(backend): Conversation memory (Redis, session mgmt) #37

### DIFF
--- a/apps/backend/app/api/routes/conversation_memory.py
+++ b/apps/backend/app/api/routes/conversation_memory.py
@@ -1,0 +1,215 @@
+"""REST endpoints for conversation memory (session management)."""
+
+from typing import Annotated
+
+import structlog
+from fastapi import APIRouter, Query
+from starlette import status
+
+from app.core.exceptions import ConflictError, NotFoundError
+from app.schemas.conversation_memory import (
+    ContextWindowUsage,
+    ConversationContextResponse,
+    ConversationCreateRequest,
+    ConversationMessageCreateRequest,
+    ConversationMessageResponse,
+    ConversationMessagesResponse,
+    ConversationSessionResponse,
+    ConversationSummaryResponse,
+)
+from app.services.conversation_memory_service import (
+    SessionEndedError,
+    SessionNotFoundError,
+    conversation_memory_service,
+)
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger()
+
+router = APIRouter(prefix="/api/v1/conversations", tags=["conversations"])
+
+
+@router.post(
+    "",
+    response_model=ConversationSessionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_session(
+    body: ConversationCreateRequest,
+) -> ConversationSessionResponse:
+    """Create a new conversation session."""
+    session = await conversation_memory_service.create_session(
+        user_id=body.user_id,
+        project_id=body.project_id,
+        ttl_seconds=body.ttl_seconds,
+    )
+    return ConversationSessionResponse(
+        session_id=session.session_id,
+        user_id=session.user_id,
+        project_id=session.project_id,
+        status=session.status,
+        message_count=session.message_count,
+        total_tokens=session.total_tokens,
+        created_at=session.created_at,
+        last_activity_at=session.last_activity_at,
+        summary=session.summary,
+    )
+
+
+@router.get(
+    "/{session_id}",
+    response_model=ConversationSessionResponse,
+)
+async def get_session(
+    session_id: str,
+) -> ConversationSessionResponse:
+    """Get session information."""
+    try:
+        session = await conversation_memory_service.get_session(session_id)
+    except SessionNotFoundError as exc:
+        raise NotFoundError(message=str(exc)) from exc
+    return ConversationSessionResponse(
+        session_id=session.session_id,
+        user_id=session.user_id,
+        project_id=session.project_id,
+        status=session.status,
+        message_count=session.message_count,
+        total_tokens=session.total_tokens,
+        created_at=session.created_at,
+        last_activity_at=session.last_activity_at,
+        summary=session.summary,
+    )
+
+
+@router.delete(
+    "/{session_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def end_session(
+    session_id: str,
+) -> None:
+    """End a conversation session (creates summary, cleans up)."""
+    try:
+        await conversation_memory_service.end_session(session_id)
+    except SessionNotFoundError as exc:
+        raise NotFoundError(message=str(exc)) from exc
+
+
+@router.get(
+    "/{session_id}/messages",
+    response_model=ConversationMessagesResponse,
+)
+async def get_messages(
+    session_id: str,
+    limit: Annotated[
+        int,
+        Query(ge=1, le=200, description="Maksimum mesaj sayisi"),
+    ] = 50,
+    offset: Annotated[
+        int,
+        Query(ge=0, description="Baslangic pozisyonu"),
+    ] = 0,
+) -> ConversationMessagesResponse:
+    """Get message history for a session."""
+    try:
+        messages, total, has_more = await conversation_memory_service.get_messages(
+            session_id=session_id,
+            limit=limit,
+            offset=offset,
+        )
+    except SessionNotFoundError as exc:
+        raise NotFoundError(message=str(exc)) from exc
+    return ConversationMessagesResponse(
+        messages=[
+            ConversationMessageResponse(
+                id=msg.id,
+                role=msg.role,
+                content=msg.content,
+                timestamp=msg.timestamp,
+                token_count=msg.token_count,
+                metadata=msg.metadata,
+            )
+            for msg in messages
+        ],
+        total=total,
+        has_more=has_more,
+    )
+
+
+@router.post(
+    "/{session_id}/messages",
+    response_model=ConversationMessageResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_message(
+    session_id: str,
+    body: ConversationMessageCreateRequest,
+) -> ConversationMessageResponse:
+    """Add a message to the conversation."""
+    from app.core.config import get_settings
+
+    try:
+        message = await conversation_memory_service.add_message(
+            session_id=session_id,
+            role=body.role,
+            content=body.content,
+            metadata=body.metadata,
+        )
+    except SessionNotFoundError as exc:
+        raise NotFoundError(message=str(exc)) from exc
+    except SessionEndedError as exc:
+        raise ConflictError(message=str(exc)) from exc
+
+    # Get updated session for context window usage
+    session = await conversation_memory_service.get_session(session_id)
+    settings = get_settings()
+    max_tokens = settings.conversation_max_tokens
+    usage_percent = round((session.total_tokens / max_tokens) * 100, 1) if max_tokens > 0 else 0.0
+
+    return ConversationMessageResponse(
+        id=message.id,
+        role=message.role,
+        content=message.content,
+        timestamp=message.timestamp,
+        token_count=message.token_count,
+        metadata=message.metadata,
+        context_window_usage=ContextWindowUsage(
+            total_tokens=session.total_tokens,
+            max_tokens=max_tokens,
+            usage_percent=usage_percent,
+        ),
+    )
+
+
+@router.post(
+    "/{session_id}/summarize",
+    response_model=ConversationSummaryResponse,
+)
+async def summarize_session(
+    session_id: str,
+) -> ConversationSummaryResponse:
+    """Create a session summary."""
+    try:
+        return await conversation_memory_service.summarize_session(session_id)
+    except SessionNotFoundError as exc:
+        raise NotFoundError(message=str(exc)) from exc
+
+
+@router.get(
+    "/{session_id}/context",
+    response_model=ConversationContextResponse,
+)
+async def get_context(
+    session_id: str,
+    max_tokens: Annotated[
+        int | None,
+        Query(ge=1000, le=100000, description="Maksimum token limiti"),
+    ] = None,
+) -> ConversationContextResponse:
+    """Get context-window-optimized message history."""
+    try:
+        return await conversation_memory_service.get_context_window(
+            session_id=session_id,
+            max_tokens=max_tokens,
+        )
+    except SessionNotFoundError as exc:
+        raise NotFoundError(message=str(exc)) from exc

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -64,6 +64,10 @@ class Settings(BaseSettings):
     # Approval
     approval_timeout_seconds: int = 300
 
+    # Conversation Memory
+    conversation_ttl_seconds: int = 86400  # 24 hours
+    conversation_max_tokens: int = 50000  # Context window token limit
+
 
 def get_settings() -> Settings:
     """Return application settings singleton."""

--- a/apps/backend/app/core/exceptions.py
+++ b/apps/backend/app/core/exceptions.py
@@ -45,6 +45,16 @@ class ValidationError(AppError):
         )
 
 
+class ConflictError(AppError):
+    """Conflict error (e.g., trying to modify an ended resource)."""
+
+    def __init__(self, message: str = "Conflict") -> None:
+        super().__init__(
+            message=message,
+            status_code=status.HTTP_409_CONFLICT,
+        )
+
+
 def register_exception_handlers(app: FastAPI) -> None:
     """Register global exception handlers on the FastAPI app."""
 

--- a/apps/backend/app/core/redis.py
+++ b/apps/backend/app/core/redis.py
@@ -123,6 +123,149 @@ class RedisClient:
         messages.append(message)
         await self.save_conversation(session_id, messages, ttl=ttl)
 
+    # --- Session-based conversation memory (hash + list) ---
+
+    async def hset_mapping(self, key: str, mapping: dict[str, str], ttl: int = 0) -> None:
+        """Set multiple hash fields from a mapping.
+
+        Args:
+            key: Redis key.
+            mapping: Field-value mapping.
+            ttl: Optional TTL in seconds (0 = no expiry).
+        """
+        client = await self._get_client()
+        await client.hset(key, mapping=mapping)  # type: ignore[misc]
+        if ttl > 0:
+            await client.expire(key, ttl)
+
+    async def hset_field(self, key: str, field: str, value: str) -> None:
+        """Set a single hash field.
+
+        Args:
+            key: Redis key.
+            field: Hash field name.
+            value: Field value.
+        """
+        client = await self._get_client()
+        await client.hset(key, field, value)  # type: ignore[misc]
+
+    async def hgetall(self, key: str) -> dict[str, str]:
+        """Get all hash fields.
+
+        Args:
+            key: Redis key.
+
+        Returns:
+            Dict of field-value pairs (empty if key doesn't exist).
+        """
+        client = await self._get_client()
+        result: dict[str, str] = await client.hgetall(key)  # type: ignore[misc]
+        return result
+
+    async def rpush(self, key: str, value: str, ttl: int = 0) -> int:
+        """Append a value to a list (right push).
+
+        Args:
+            key: Redis key.
+            value: Value to push.
+            ttl: Optional TTL in seconds (0 = no expiry).
+
+        Returns:
+            Length of the list after push.
+        """
+        client = await self._get_client()
+        length: int = await client.rpush(key, value)  # type: ignore[misc]
+        if ttl > 0:
+            await client.expire(key, ttl)
+        return length
+
+    async def llen(self, key: str) -> int:
+        """Get the length of a list.
+
+        Args:
+            key: Redis key.
+
+        Returns:
+            Length of the list.
+        """
+        client = await self._get_client()
+        result: int = await client.llen(key)  # type: ignore[misc]
+        return result
+
+    async def lrange(self, key: str, start: int, stop: int) -> list[str]:
+        """Get a range of elements from a list.
+
+        Args:
+            key: Redis key.
+            start: Start index.
+            stop: Stop index (-1 for all).
+
+        Returns:
+            List of string values.
+        """
+        client = await self._get_client()
+        result: list[str] = await client.lrange(key, start, stop)  # type: ignore[misc]
+        return result
+
+    async def sadd(self, key: str, member: str, ttl: int = 0) -> None:
+        """Add a member to a set.
+
+        Args:
+            key: Redis key.
+            member: Set member.
+            ttl: Optional TTL in seconds (0 = no expiry).
+        """
+        client = await self._get_client()
+        await client.sadd(key, member)  # type: ignore[misc]
+        if ttl > 0:
+            await client.expire(key, ttl)
+
+    async def srem(self, key: str, member: str) -> None:
+        """Remove a member from a set.
+
+        Args:
+            key: Redis key.
+            member: Set member.
+        """
+        client = await self._get_client()
+        await client.srem(key, member)  # type: ignore[misc]
+
+    async def smembers(self, key: str) -> set[str]:
+        """Get all members of a set.
+
+        Args:
+            key: Redis key.
+
+        Returns:
+            Set of string members.
+        """
+        client = await self._get_client()
+        result: set[str] = await client.smembers(key)  # type: ignore[misc]
+        return result
+
+    async def expire(self, key: str, ttl: int) -> None:
+        """Set a TTL on a key.
+
+        Args:
+            key: Redis key.
+            ttl: Time-to-live in seconds.
+        """
+        client = await self._get_client()
+        await client.expire(key, ttl)
+
+    async def delete_key(self, key: str) -> bool:
+        """Delete a key.
+
+        Args:
+            key: Redis key.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        client = await self._get_client()
+        deleted = await client.delete(key)
+        return bool(deleted)
+
     # --- Generic cache operations ---
 
     async def set_cache(self, key: str, value: str, ttl: int = 300) -> None:

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -12,6 +12,7 @@ from app.api.middleware.request_logging import RequestLoggingMiddleware
 from app.api.routes.agent_ws import router as agent_ws_router
 from app.api.routes.agents import router as agents_router
 from app.api.routes.auth import router as auth_router
+from app.api.routes.conversation_memory import router as conversation_memory_router
 from app.api.routes.cost import router as cost_router
 from app.api.routes.files import router as files_router
 from app.api.routes.health import router as health_router
@@ -79,6 +80,7 @@ def create_app() -> FastAPI:
     application.include_router(agents_router)
     application.include_router(webhooks_router)
     application.include_router(memory_router)
+    application.include_router(conversation_memory_router)
     application.include_router(projects_router)
     application.include_router(cost_router)
     application.include_router(files_router)

--- a/apps/backend/app/schemas/conversation_memory.py
+++ b/apps/backend/app/schemas/conversation_memory.py
@@ -1,0 +1,125 @@
+"""Pydantic schemas for conversation memory (Redis session management)."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# --- Domain entities (frozen) ---
+
+
+class ConversationMessage(BaseModel):
+    """Immutable conversation message entity."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    role: str  # "user" | "assistant" | "tool" | "system"
+    content: str
+    timestamp: datetime
+    token_count: int
+    metadata: dict[str, str] | None = None
+
+
+class ConversationSession(BaseModel):
+    """Immutable conversation session entity."""
+
+    model_config = ConfigDict(frozen=True)
+
+    session_id: str
+    user_id: str
+    project_id: str | None = None
+    status: str  # "active" | "ended" | "summarized"
+    message_count: int
+    total_tokens: int
+    created_at: datetime
+    last_activity_at: datetime | None = None
+    summary: str | None = None
+
+
+# --- Request schemas ---
+
+
+class ConversationCreateRequest(BaseModel):
+    """Request to create a new conversation session."""
+
+    user_id: str = Field(min_length=1, max_length=100)
+    project_id: str | None = Field(default=None, description="Opsiyonel proje ID")
+    ttl_seconds: int | None = Field(
+        default=None,
+        ge=60,
+        le=172800,
+        description="Session TTL suresi (saniye). Varsayilan: 86400",
+    )
+
+
+class ConversationMessageCreateRequest(BaseModel):
+    """Request to add a message to a conversation."""
+
+    role: str = Field(pattern=r"^(user|assistant|tool|system)$")
+    content: str = Field(min_length=1, max_length=100000)
+    metadata: dict[str, str] | None = None
+
+
+# --- Response schemas ---
+
+
+class ContextWindowUsage(BaseModel):
+    """Context window usage info."""
+
+    total_tokens: int
+    max_tokens: int
+    usage_percent: float
+
+
+class ConversationSessionResponse(BaseModel):
+    """Response for a conversation session."""
+
+    session_id: str
+    user_id: str
+    project_id: str | None = None
+    status: str
+    message_count: int
+    total_tokens: int
+    created_at: datetime
+    last_activity_at: datetime | None = None
+    summary: str | None = None
+
+
+class ConversationMessageResponse(BaseModel):
+    """Response for a single message."""
+
+    id: str
+    role: str
+    content: str
+    timestamp: datetime
+    token_count: int
+    metadata: dict[str, str] | None = None
+    context_window_usage: ContextWindowUsage | None = None
+
+
+class ConversationMessagesResponse(BaseModel):
+    """Response for message list."""
+
+    messages: list[ConversationMessageResponse]
+    total: int
+    has_more: bool
+
+
+class ConversationSummaryResponse(BaseModel):
+    """Response for session summary."""
+
+    session_id: str
+    summary: str
+    original_message_count: int
+    original_token_count: int
+    summary_token_count: int
+
+
+class ConversationContextResponse(BaseModel):
+    """Response for context window optimized messages."""
+
+    messages: list[dict[str, str]]
+    summary: str | None = None
+    total_tokens: int
+    messages_included: int
+    messages_summarized: int

--- a/apps/backend/app/services/conversation_memory_service.py
+++ b/apps/backend/app/services/conversation_memory_service.py
@@ -1,0 +1,508 @@
+"""Conversation memory service - Redis-based session management.
+
+Manages conversation sessions with:
+- Session lifecycle (create, get, end)
+- Message storage (append, retrieve with pagination)
+- TTL-based auto-cleanup
+- Context window management (token limiting)
+- Session summarization
+"""
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+import structlog
+
+from app.core.config import get_settings
+from app.core.redis import redis_client
+from app.schemas.conversation_memory import (
+    ConversationContextResponse,
+    ConversationMessage,
+    ConversationSession,
+    ConversationSummaryResponse,
+)
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger()
+
+# Redis key prefixes
+_SESSION_META_PREFIX = "conv:session:"
+_SESSION_META_SUFFIX = ":meta"
+_SESSION_MSGS_SUFFIX = ":messages"
+_SESSION_SUMMARY_SUFFIX = ":summary"
+_USER_SESSIONS_PREFIX = "conv:user:"
+_USER_SESSIONS_SUFFIX = ":sessions"
+
+# Token estimation: 1 token ~ 4 characters
+_CHARS_PER_TOKEN = 4
+
+
+class ConversationMemoryError(Exception):
+    """Raised when a conversation memory operation fails."""
+
+    def __init__(self, message: str, operation: str = "") -> None:
+        self.operation = operation
+        super().__init__(message)
+
+
+class SessionNotFoundError(ConversationMemoryError):
+    """Raised when a session is not found in Redis."""
+
+    def __init__(self, session_id: str) -> None:
+        super().__init__(
+            f"Session '{session_id}' bulunamadi",
+            operation="get_session",
+        )
+
+
+class SessionEndedError(ConversationMemoryError):
+    """Raised when trying to modify an ended session."""
+
+    def __init__(self, session_id: str) -> None:
+        super().__init__(
+            f"Session '{session_id}' sonlandirilmis, mesaj eklenemez",
+            operation="add_message",
+        )
+
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count from character length.
+
+    Args:
+        text: Input text.
+
+    Returns:
+        Estimated token count.
+    """
+    return max(1, len(text) // _CHARS_PER_TOKEN)
+
+
+def _meta_key(session_id: str) -> str:
+    return f"{_SESSION_META_PREFIX}{session_id}{_SESSION_META_SUFFIX}"
+
+
+def _msgs_key(session_id: str) -> str:
+    return f"{_SESSION_META_PREFIX}{session_id}{_SESSION_MSGS_SUFFIX}"
+
+
+def _summary_key(session_id: str) -> str:
+    return f"{_SESSION_META_PREFIX}{session_id}{_SESSION_SUMMARY_SUFFIX}"
+
+
+def _user_sessions_key(user_id: str) -> str:
+    return f"{_USER_SESSIONS_PREFIX}{user_id}{_USER_SESSIONS_SUFFIX}"
+
+
+class ConversationMemoryService:
+    """Redis-based conversation memory management.
+
+    Handles full session lifecycle with message storage,
+    TTL management, and context window optimization.
+    """
+
+    async def create_session(
+        self,
+        user_id: str,
+        project_id: str | None = None,
+        ttl_seconds: int | None = None,
+    ) -> ConversationSession:
+        """Create a new conversation session.
+
+        Args:
+            user_id: User identifier.
+            project_id: Optional project identifier.
+            ttl_seconds: Optional TTL override (seconds).
+
+        Returns:
+            Created ConversationSession.
+        """
+        settings = get_settings()
+        ttl = ttl_seconds if ttl_seconds is not None else settings.conversation_ttl_seconds
+        session_id = str(uuid.uuid4())
+        now = datetime.now(tz=UTC)
+
+        meta: dict[str, str] = {
+            "session_id": session_id,
+            "user_id": user_id,
+            "project_id": project_id or "",
+            "status": "active",
+            "message_count": "0",
+            "total_tokens": "0",
+            "created_at": now.isoformat(),
+            "last_activity_at": now.isoformat(),
+        }
+
+        key = _meta_key(session_id)
+
+        # Store session metadata as a hash
+        await redis_client.hset_mapping(key, meta, ttl=ttl)
+
+        # Track user's active sessions
+        user_key = _user_sessions_key(user_id)
+        await redis_client.sadd(user_key, session_id, ttl=ttl)
+
+        await logger.ainfo(
+            "conversation_session_created",
+            session_id=session_id,
+            user_id=user_id,
+            ttl_seconds=ttl,
+        )
+
+        return ConversationSession(
+            session_id=session_id,
+            user_id=user_id,
+            project_id=project_id,
+            status="active",
+            message_count=0,
+            total_tokens=0,
+            created_at=now,
+            last_activity_at=now,
+            summary=None,
+        )
+
+    async def get_session(self, session_id: str) -> ConversationSession:
+        """Retrieve session metadata.
+
+        Args:
+            session_id: Session identifier.
+
+        Returns:
+            ConversationSession.
+
+        Raises:
+            SessionNotFoundError: If session does not exist.
+        """
+        key = _meta_key(session_id)
+        meta = await redis_client.hgetall(key)
+
+        if not meta:
+            raise SessionNotFoundError(session_id)
+
+        # Get summary if exists
+        s_key = _summary_key(session_id)
+        summary = await redis_client.get_cache(s_key)
+
+        return ConversationSession(
+            session_id=meta["session_id"],
+            user_id=meta["user_id"],
+            project_id=meta["project_id"] or None,
+            status=meta["status"],
+            message_count=int(meta["message_count"]),
+            total_tokens=int(meta["total_tokens"]),
+            created_at=datetime.fromisoformat(meta["created_at"]),
+            last_activity_at=datetime.fromisoformat(meta["last_activity_at"])
+            if meta.get("last_activity_at")
+            else None,
+            summary=summary,
+        )
+
+    async def add_message(
+        self,
+        session_id: str,
+        role: str,
+        content: str,
+        metadata: dict[str, str] | None = None,
+    ) -> ConversationMessage:
+        """Add a message to a conversation session.
+
+        Appends the message to the Redis list, updates session metadata,
+        and refreshes TTL.
+
+        Args:
+            session_id: Session identifier.
+            role: Message role (user, assistant, tool, system).
+            content: Message content.
+            metadata: Optional message metadata.
+
+        Returns:
+            Created ConversationMessage.
+
+        Raises:
+            SessionNotFoundError: If session does not exist.
+            SessionEndedError: If session has been ended.
+        """
+        session = await self.get_session(session_id)
+
+        if session.status != "active":
+            raise SessionEndedError(session_id)
+
+        settings = get_settings()
+        ttl = settings.conversation_ttl_seconds
+
+        msg_id = str(uuid.uuid4())
+        now = datetime.now(tz=UTC)
+        token_count = _estimate_tokens(content)
+
+        message = ConversationMessage(
+            id=msg_id,
+            role=role,
+            content=content,
+            timestamp=now,
+            token_count=token_count,
+            metadata=metadata,
+        )
+
+        # Append message to list
+        msgs_key = _msgs_key(session_id)
+        msg_json = json.dumps(message.model_dump(mode="json"))
+        await redis_client.rpush(msgs_key, msg_json, ttl=ttl)
+
+        # Update session metadata
+        meta_key = _meta_key(session_id)
+        new_count = session.message_count + 1
+        new_tokens = session.total_tokens + token_count
+        await redis_client.hset_mapping(
+            meta_key,
+            {
+                "message_count": str(new_count),
+                "total_tokens": str(new_tokens),
+                "last_activity_at": now.isoformat(),
+            },
+        )
+        await redis_client.expire(meta_key, ttl)
+
+        await logger.ainfo(
+            "conversation_message_added",
+            session_id=session_id,
+            role=role,
+            token_count=token_count,
+            total_tokens=new_tokens,
+        )
+
+        return message
+
+    async def get_messages(
+        self,
+        session_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[ConversationMessage], int, bool]:
+        """Retrieve messages for a session with pagination.
+
+        Args:
+            session_id: Session identifier.
+            limit: Maximum number of messages to return.
+            offset: Starting position.
+
+        Returns:
+            Tuple of (messages, total_count, has_more).
+
+        Raises:
+            SessionNotFoundError: If session does not exist.
+        """
+        # Verify session exists
+        await self.get_session(session_id)
+
+        msgs_key = _msgs_key(session_id)
+
+        total = await redis_client.llen(msgs_key)
+        end = offset + limit - 1
+        raw_messages = await redis_client.lrange(msgs_key, offset, end)
+
+        messages: list[ConversationMessage] = []
+        for raw in raw_messages:
+            data = json.loads(raw)
+            messages.append(ConversationMessage(**data))
+
+        has_more = (offset + limit) < total
+
+        return messages, total, has_more
+
+    async def get_context_window(
+        self,
+        session_id: str,
+        max_tokens: int | None = None,
+    ) -> ConversationContextResponse:
+        """Get context-window-optimized message history.
+
+        Returns the most recent messages that fit within the token budget.
+        If there are older messages that don't fit, they are counted as
+        summarized. If a session summary exists, it is included.
+
+        Args:
+            session_id: Session identifier.
+            max_tokens: Maximum token limit. Defaults to config value.
+
+        Returns:
+            ConversationContextResponse with optimized messages.
+
+        Raises:
+            SessionNotFoundError: If session does not exist.
+        """
+        settings = get_settings()
+        budget = max_tokens if max_tokens is not None else settings.conversation_max_tokens
+
+        session = await self.get_session(session_id)
+
+        msgs_key = _msgs_key(session_id)
+
+        # Get all messages from Redis
+        raw_all = await redis_client.lrange(msgs_key, 0, -1)
+
+        all_messages: list[ConversationMessage] = []
+        for raw in raw_all:
+            data = json.loads(raw)
+            all_messages.append(ConversationMessage(**data))
+
+        # Include summary token cost if available
+        summary = session.summary
+        summary_tokens = _estimate_tokens(summary) if summary else 0
+        remaining_budget = budget - summary_tokens
+
+        # Walk backwards from most recent, include messages that fit
+        included: list[dict[str, str]] = []
+        included_tokens = 0
+        cutoff_index = len(all_messages)
+
+        for i in range(len(all_messages) - 1, -1, -1):
+            msg = all_messages[i]
+            if included_tokens + msg.token_count > remaining_budget:
+                cutoff_index = i + 1
+                break
+            included_tokens += msg.token_count
+            included.insert(0, {"role": msg.role, "content": msg.content})
+            cutoff_index = i
+
+        messages_summarized = cutoff_index
+        total_tokens = included_tokens + summary_tokens
+
+        return ConversationContextResponse(
+            messages=included,
+            summary=summary,
+            total_tokens=total_tokens,
+            messages_included=len(included),
+            messages_summarized=messages_summarized,
+        )
+
+    async def summarize_session(
+        self,
+        session_id: str,
+        summary_text: str | None = None,
+    ) -> ConversationSummaryResponse:
+        """Create a session summary.
+
+        If summary_text is provided, it is used directly. Otherwise, a
+        simple truncation-based summary is generated from the messages.
+        (Full AI summarization is handled by the orchestrator layer.)
+
+        Args:
+            session_id: Session identifier.
+            summary_text: Optional pre-generated summary text.
+
+        Returns:
+            ConversationSummaryResponse.
+
+        Raises:
+            SessionNotFoundError: If session does not exist.
+        """
+        session = await self.get_session(session_id)
+
+        msgs_key = _msgs_key(session_id)
+
+        # Get all messages
+        raw_all = await redis_client.lrange(msgs_key, 0, -1)
+        original_count = len(raw_all)
+        original_tokens = session.total_tokens
+
+        if summary_text is None:
+            # Simple truncation-based summary from messages
+            parts: list[str] = []
+            for raw in raw_all:
+                data = json.loads(raw)
+                role = data.get("role", "unknown")
+                content = data.get("content", "")
+                # Truncate long messages
+                if len(content) > 200:
+                    content = content[:200] + "..."
+                parts.append(f"{role}: {content}")
+            full_text = "\n".join(parts)
+            # Truncate to ~500 tokens (2000 chars)
+            if len(full_text) > 2000:
+                summary_text = full_text[:2000] + "\n[...truncated]"
+            else:
+                summary_text = full_text
+
+        summary_token_count = _estimate_tokens(summary_text)
+
+        # Store summary in Redis
+        s_key = _summary_key(session_id)
+        settings = get_settings()
+        ttl = settings.conversation_ttl_seconds
+        await redis_client.set_cache(s_key, summary_text, ttl=ttl)
+
+        # Update session status
+        meta_key = _meta_key(session_id)
+        await redis_client.hset_field(meta_key, "status", "summarized")
+
+        await logger.ainfo(
+            "conversation_session_summarized",
+            session_id=session_id,
+            original_count=original_count,
+            summary_tokens=summary_token_count,
+        )
+
+        return ConversationSummaryResponse(
+            session_id=session_id,
+            summary=summary_text,
+            original_message_count=original_count,
+            original_token_count=original_tokens,
+            summary_token_count=summary_token_count,
+        )
+
+    async def end_session(
+        self,
+        session_id: str,
+    ) -> None:
+        """End a conversation session.
+
+        Creates a summary, updates status, and cleans up message data
+        (keeping only metadata and summary).
+
+        Args:
+            session_id: Session identifier.
+
+        Raises:
+            SessionNotFoundError: If session does not exist.
+        """
+        session = await self.get_session(session_id)
+
+        # Generate summary before cleanup
+        if session.status == "active":
+            await self.summarize_session(session_id)
+
+        # Update status to ended
+        meta_key = _meta_key(session_id)
+        await redis_client.hset_field(meta_key, "status", "ended")
+
+        # Delete the messages list (keep meta + summary)
+        msgs_key = _msgs_key(session_id)
+        await redis_client.delete_key(msgs_key)
+
+        # Remove from user's active sessions
+        user_id = session.user_id
+        user_key = _user_sessions_key(user_id)
+        await redis_client.srem(user_key, session_id)
+
+        await logger.ainfo(
+            "conversation_session_ended",
+            session_id=session_id,
+            user_id=user_id,
+            message_count=session.message_count,
+        )
+
+    async def get_user_sessions(self, user_id: str) -> list[str]:
+        """Get all active session IDs for a user.
+
+        Args:
+            user_id: User identifier.
+
+        Returns:
+            List of session IDs.
+        """
+        user_key = _user_sessions_key(user_id)
+        session_ids = await redis_client.smembers(user_key)
+        return list(session_ids)
+
+
+# Module-level singleton
+conversation_memory_service = ConversationMemoryService()

--- a/apps/backend/tests/contract/test_conversation_memory_contract.py
+++ b/apps/backend/tests/contract/test_conversation_memory_contract.py
@@ -1,0 +1,73 @@
+"""Contract tests for conversation memory API.
+
+Validates that backend endpoints match shared/api-contracts/rest/v1/conversation-memory.json.
+"""
+
+import json
+from pathlib import Path
+
+from app.main import app
+
+
+# Contract file relative to the repo root (two levels up from apps/backend)
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+CONTRACT_FILE = _REPO_ROOT / "shared" / "api-contracts" / "rest" / "v1" / "conversation-memory.json"
+
+
+def _load_contract() -> list[dict[str, object]]:
+    """Load conversation memory contract endpoints."""
+    if not CONTRACT_FILE.exists():
+        return []
+    with open(CONTRACT_FILE) as f:
+        data = json.load(f)
+    endpoints: list[dict[str, object]] = data.get("endpoints", [])
+    return endpoints
+
+
+def _get_app_routes() -> dict[str, set[str]]:
+    """Build a mapping of path -> set of methods from the FastAPI app."""
+    routes: dict[str, set[str]] = {}
+    for route in app.routes:
+        if hasattr(route, "path") and hasattr(route, "methods"):
+            path = str(route.path)
+            if path not in routes:
+                routes[path] = set()
+            for m in route.methods:
+                routes[path].add(str(m))
+    return routes
+
+
+class TestConversationMemoryContract:
+    """Validates conversation memory endpoints match contract."""
+
+    def test_contract_file_exists(self) -> None:
+        """Contract file should exist."""
+        assert CONTRACT_FILE.exists(), f"Contract file not found: {CONTRACT_FILE}"
+
+    def test_all_endpoints_registered(self) -> None:
+        """All contract endpoints should be registered in the app."""
+        endpoints = _load_contract()
+        app_routes = _get_app_routes()
+
+        for ep in endpoints:
+            method = str(ep.get("method", "")).upper()
+            path = str(ep.get("path", ""))
+
+            # Convert path params: {session_id} -> {session_id} (FastAPI format)
+            # They should match directly since FastAPI uses the same format
+            assert path in app_routes, (
+                f"Endpoint {method} {path} not found in app routes. "
+                f"Available: {list(app_routes.keys())}"
+            )
+            assert method in app_routes[path], (
+                f"Method {method} not registered for {path}. "
+                f"Available methods: {app_routes[path]}"
+            )
+
+    def test_endpoint_count_matches(self) -> None:
+        """Number of contract endpoints should match registered endpoints."""
+        endpoints = _load_contract()
+        # We expect 7 endpoints for conversation memory
+        assert len(endpoints) == 7, (
+            f"Expected 7 contract endpoints, got {len(endpoints)}"
+        )

--- a/apps/backend/tests/contract/test_conversation_memory_contract.py
+++ b/apps/backend/tests/contract/test_conversation_memory_contract.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 from app.main import app
 
-
 # Contract file relative to the repo root (two levels up from apps/backend)
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 CONTRACT_FILE = _REPO_ROOT / "shared" / "api-contracts" / "rest" / "v1" / "conversation-memory.json"

--- a/apps/backend/tests/integration/test_api/test_conversation_memory_endpoints.py
+++ b/apps/backend/tests/integration/test_api/test_conversation_memory_endpoints.py
@@ -1,0 +1,145 @@
+"""Integration tests for conversation memory REST endpoints."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.fixture
+async def client() -> AsyncClient:
+    """Create an async test client."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+class TestCreateSessionEndpoint:
+    """Tests for POST /api/v1/conversations."""
+
+    async def test_create_session_success(self, client: AsyncClient) -> None:
+        """Should create a session and return 201."""
+        with (
+            patch(
+                "app.services.conversation_memory_service.redis_client"
+            ) as mock_redis,
+            patch(
+                "app.services.conversation_memory_service.get_settings"
+            ) as mock_settings,
+        ):
+            mock_settings.return_value.conversation_ttl_seconds = 86400
+            mock_redis.hset_mapping = AsyncMock()
+            mock_redis.sadd = AsyncMock()
+
+            response = await client.post(
+                "/api/v1/conversations",
+                json={"user_id": "testuser", "project_id": "proj-1"},
+            )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["user_id"] == "testuser"
+        assert data["project_id"] == "proj-1"
+        assert data["status"] == "active"
+        assert data["message_count"] == 0
+        assert "session_id" in data
+
+    async def test_create_session_missing_user_id(
+        self, client: AsyncClient
+    ) -> None:
+        """Should return 422 for missing user_id."""
+        response = await client.post(
+            "/api/v1/conversations",
+            json={},
+        )
+        assert response.status_code == 422
+
+
+class TestGetSessionEndpoint:
+    """Tests for GET /api/v1/conversations/{session_id}."""
+
+    async def test_get_session_not_found(self, client: AsyncClient) -> None:
+        """Should return 404 for nonexistent session."""
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.hgetall = AsyncMock(return_value={})
+
+            response = await client.get(
+                "/api/v1/conversations/nonexistent-id"
+            )
+
+        assert response.status_code == 404
+
+
+class TestAddMessageEndpoint:
+    """Tests for POST /api/v1/conversations/{session_id}/messages."""
+
+    async def test_add_message_to_nonexistent_session(
+        self, client: AsyncClient
+    ) -> None:
+        """Should return 404 for nonexistent session."""
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.hgetall = AsyncMock(return_value={})
+
+            response = await client.post(
+                "/api/v1/conversations/nonexistent/messages",
+                json={"role": "user", "content": "Hello"},
+            )
+
+        assert response.status_code == 404
+
+    async def test_add_message_invalid_role(
+        self, client: AsyncClient
+    ) -> None:
+        """Should return 422 for invalid role."""
+        response = await client.post(
+            "/api/v1/conversations/sess-123/messages",
+            json={"role": "invalid_role", "content": "Hello"},
+        )
+        assert response.status_code == 422
+
+
+class TestEndSessionEndpoint:
+    """Tests for DELETE /api/v1/conversations/{session_id}."""
+
+    async def test_end_nonexistent_session(
+        self, client: AsyncClient
+    ) -> None:
+        """Should return 404 for nonexistent session."""
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.hgetall = AsyncMock(return_value={})
+
+            response = await client.delete(
+                "/api/v1/conversations/nonexistent"
+            )
+
+        assert response.status_code == 404
+
+
+class TestGetMessagesEndpoint:
+    """Tests for GET /api/v1/conversations/{session_id}/messages."""
+
+    async def test_get_messages_invalid_limit(
+        self, client: AsyncClient
+    ) -> None:
+        """Should return 422 for invalid limit parameter."""
+        response = await client.get(
+            "/api/v1/conversations/sess-123/messages?limit=0"
+        )
+        assert response.status_code == 422
+
+    async def test_get_messages_invalid_offset(
+        self, client: AsyncClient
+    ) -> None:
+        """Should return 422 for negative offset parameter."""
+        response = await client.get(
+            "/api/v1/conversations/sess-123/messages?offset=-1"
+        )
+        assert response.status_code == 422

--- a/apps/backend/tests/unit/test_services/test_conversation_memory_service.py
+++ b/apps/backend/tests/unit/test_services/test_conversation_memory_service.py
@@ -1,0 +1,705 @@
+"""Unit tests for ConversationMemoryService."""
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.conversation_memory_service import (
+    ConversationMemoryService,
+    SessionEndedError,
+    SessionNotFoundError,
+    _estimate_tokens,
+)
+
+
+class TestEstimateTokens:
+    """Tests for _estimate_tokens helper."""
+
+    def test_empty_string_returns_one(self) -> None:
+        """Empty string should return minimum 1 token."""
+        assert _estimate_tokens("") == 1
+
+    def test_short_string(self) -> None:
+        """Short string should return at least 1."""
+        assert _estimate_tokens("Hi") == 1
+
+    def test_standard_string(self) -> None:
+        """Standard string should return chars / 4."""
+        assert _estimate_tokens("12345678") == 2
+
+    def test_long_string(self) -> None:
+        """Long string should return proportional tokens."""
+        text = "a" * 4000
+        assert _estimate_tokens(text) == 1000
+
+
+class TestCreateSession:
+    """Tests for ConversationMemoryService.create_session."""
+
+    async def test_create_session_success(self) -> None:
+        """create_session should store metadata in Redis and return session."""
+        svc = ConversationMemoryService()
+
+        with (
+            patch(
+                "app.services.conversation_memory_service.redis_client"
+            ) as mock_redis,
+            patch(
+                "app.services.conversation_memory_service.get_settings"
+            ) as mock_settings,
+        ):
+            mock_settings.return_value.conversation_ttl_seconds = 86400
+            mock_redis.hset_mapping = AsyncMock()
+            mock_redis.sadd = AsyncMock()
+
+            session = await svc.create_session(user_id="user1", project_id="proj1")
+
+        assert session.user_id == "user1"
+        assert session.project_id == "proj1"
+        assert session.status == "active"
+        assert session.message_count == 0
+        assert session.total_tokens == 0
+        assert session.session_id  # Non-empty UUID string
+        mock_redis.hset_mapping.assert_called_once()
+        mock_redis.sadd.assert_called_once()
+
+    async def test_create_session_custom_ttl(self) -> None:
+        """create_session should use custom TTL when provided."""
+        svc = ConversationMemoryService()
+
+        with (
+            patch(
+                "app.services.conversation_memory_service.redis_client"
+            ) as mock_redis,
+            patch(
+                "app.services.conversation_memory_service.get_settings"
+            ) as mock_settings,
+        ):
+            mock_settings.return_value.conversation_ttl_seconds = 86400
+            mock_redis.hset_mapping = AsyncMock()
+            mock_redis.sadd = AsyncMock()
+
+            session = await svc.create_session(
+                user_id="user1", ttl_seconds=3600
+            )
+
+        assert session.status == "active"
+        # Verify custom TTL was passed
+        call_args = mock_redis.hset_mapping.call_args
+        assert call_args.kwargs.get("ttl") == 3600 or call_args[1].get("ttl") == 3600
+
+    async def test_create_session_without_project(self) -> None:
+        """create_session should work without project_id."""
+        svc = ConversationMemoryService()
+
+        with (
+            patch(
+                "app.services.conversation_memory_service.redis_client"
+            ) as mock_redis,
+            patch(
+                "app.services.conversation_memory_service.get_settings"
+            ) as mock_settings,
+        ):
+            mock_settings.return_value.conversation_ttl_seconds = 86400
+            mock_redis.hset_mapping = AsyncMock()
+            mock_redis.sadd = AsyncMock()
+
+            session = await svc.create_session(user_id="user1")
+
+        assert session.project_id is None
+
+
+class TestGetSession:
+    """Tests for ConversationMemoryService.get_session."""
+
+    async def test_get_session_success(self) -> None:
+        """get_session should return session from Redis."""
+        svc = ConversationMemoryService()
+        now = datetime.now(tz=UTC).isoformat()
+
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "active",
+                    "message_count": "5",
+                    "total_tokens": "100",
+                    "created_at": now,
+                    "last_activity_at": now,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(return_value=None)
+
+            session = await svc.get_session("sess-123")
+
+        assert session.session_id == "sess-123"
+        assert session.user_id == "user1"
+        assert session.project_id is None  # Empty string -> None
+        assert session.status == "active"
+        assert session.message_count == 5
+        assert session.total_tokens == 100
+
+    async def test_get_session_not_found_raises(self) -> None:
+        """get_session should raise SessionNotFoundError for missing session."""
+        svc = ConversationMemoryService()
+
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.hgetall = AsyncMock(return_value={})
+
+            with pytest.raises(SessionNotFoundError, match="bulunamadi"):
+                await svc.get_session("nonexistent")
+
+    async def test_get_session_with_summary(self) -> None:
+        """get_session should include summary if available."""
+        svc = ConversationMemoryService()
+        now = datetime.now(tz=UTC).isoformat()
+
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "summarized",
+                    "message_count": "10",
+                    "total_tokens": "500",
+                    "created_at": now,
+                    "last_activity_at": now,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(
+                return_value="This is a session summary."
+            )
+
+            session = await svc.get_session("sess-123")
+
+        assert session.summary == "This is a session summary."
+        assert session.status == "summarized"
+
+
+class TestAddMessage:
+    """Tests for ConversationMemoryService.add_message."""
+
+    async def test_add_message_success(self) -> None:
+        """add_message should append to Redis and update metadata."""
+        svc = ConversationMemoryService()
+        now = datetime.now(tz=UTC).isoformat()
+
+        with (
+            patch(
+                "app.services.conversation_memory_service.redis_client"
+            ) as mock_redis,
+            patch(
+                "app.services.conversation_memory_service.get_settings"
+            ) as mock_settings,
+        ):
+            mock_settings.return_value.conversation_ttl_seconds = 86400
+            # Mock get_session
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "active",
+                    "message_count": "2",
+                    "total_tokens": "50",
+                    "created_at": now,
+                    "last_activity_at": now,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(return_value=None)
+            mock_redis.rpush = AsyncMock(return_value=3)
+            mock_redis.hset_mapping = AsyncMock()
+            mock_redis.expire = AsyncMock()
+
+            message = await svc.add_message(
+                session_id="sess-123",
+                role="user",
+                content="Hello, world!",
+            )
+
+        assert message.role == "user"
+        assert message.content == "Hello, world!"
+        assert message.token_count == _estimate_tokens("Hello, world!")
+        assert message.id  # Non-empty
+        mock_redis.rpush.assert_called_once()
+        mock_redis.hset_mapping.assert_called_once()
+
+    async def test_add_message_ended_session_raises(self) -> None:
+        """add_message should raise SessionEndedError for ended sessions."""
+        svc = ConversationMemoryService()
+        now = datetime.now(tz=UTC).isoformat()
+
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "ended",
+                    "message_count": "5",
+                    "total_tokens": "100",
+                    "created_at": now,
+                    "last_activity_at": now,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(return_value=None)
+
+            with pytest.raises(SessionEndedError, match="sonlandirilmis"):
+                await svc.add_message(
+                    session_id="sess-123",
+                    role="user",
+                    content="Should fail",
+                )
+
+    async def test_add_message_with_metadata(self) -> None:
+        """add_message should store metadata correctly."""
+        svc = ConversationMemoryService()
+        now = datetime.now(tz=UTC).isoformat()
+
+        with (
+            patch(
+                "app.services.conversation_memory_service.redis_client"
+            ) as mock_redis,
+            patch(
+                "app.services.conversation_memory_service.get_settings"
+            ) as mock_settings,
+        ):
+            mock_settings.return_value.conversation_ttl_seconds = 86400
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "active",
+                    "message_count": "0",
+                    "total_tokens": "0",
+                    "created_at": now,
+                    "last_activity_at": now,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(return_value=None)
+            mock_redis.rpush = AsyncMock(return_value=1)
+            mock_redis.hset_mapping = AsyncMock()
+            mock_redis.expire = AsyncMock()
+
+            message = await svc.add_message(
+                session_id="sess-123",
+                role="assistant",
+                content="Response",
+                metadata={"model_used": "claude-sonnet"},
+            )
+
+        assert message.metadata == {"model_used": "claude-sonnet"}
+
+
+class TestGetMessages:
+    """Tests for ConversationMemoryService.get_messages."""
+
+    async def test_get_messages_success(self) -> None:
+        """get_messages should return paginated message list."""
+        svc = ConversationMemoryService()
+        now = datetime.now(tz=UTC)
+        now_iso = now.isoformat()
+
+        msg_data = {
+            "id": "msg-1",
+            "role": "user",
+            "content": "Hello",
+            "timestamp": now_iso,
+            "token_count": 2,
+            "metadata": None,
+        }
+
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "active",
+                    "message_count": "3",
+                    "total_tokens": "30",
+                    "created_at": now_iso,
+                    "last_activity_at": now_iso,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(return_value=None)
+            mock_redis.llen = AsyncMock(return_value=3)
+            mock_redis.lrange = AsyncMock(
+                return_value=[json.dumps(msg_data)]
+            )
+
+            messages, total, has_more = await svc.get_messages(
+                "sess-123", limit=2, offset=0
+            )
+
+        assert len(messages) == 1
+        assert total == 3
+        assert messages[0].role == "user"
+
+    async def test_get_messages_has_more(self) -> None:
+        """get_messages should indicate when more messages are available."""
+        svc = ConversationMemoryService()
+        now_iso = datetime.now(tz=UTC).isoformat()
+
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "active",
+                    "message_count": "10",
+                    "total_tokens": "100",
+                    "created_at": now_iso,
+                    "last_activity_at": now_iso,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(return_value=None)
+            mock_redis.llen = AsyncMock(return_value=10)
+            mock_redis.lrange = AsyncMock(return_value=[])
+
+            _, total, has_more = await svc.get_messages(
+                "sess-123", limit=5, offset=0
+            )
+
+        assert total == 10
+        assert has_more is True
+
+    async def test_get_messages_no_more(self) -> None:
+        """get_messages should return has_more=False when at end."""
+        svc = ConversationMemoryService()
+        now_iso = datetime.now(tz=UTC).isoformat()
+
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "active",
+                    "message_count": "3",
+                    "total_tokens": "30",
+                    "created_at": now_iso,
+                    "last_activity_at": now_iso,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(return_value=None)
+            mock_redis.llen = AsyncMock(return_value=3)
+            mock_redis.lrange = AsyncMock(return_value=[])
+
+            _, total, has_more = await svc.get_messages(
+                "sess-123", limit=50, offset=0
+            )
+
+        assert total == 3
+        assert has_more is False
+
+
+class TestGetContextWindow:
+    """Tests for ConversationMemoryService.get_context_window."""
+
+    async def test_context_window_all_fit(self) -> None:
+        """get_context_window should include all messages when budget allows."""
+        svc = ConversationMemoryService()
+        now_iso = datetime.now(tz=UTC).isoformat()
+
+        msgs = [
+            json.dumps({
+                "id": f"msg-{i}",
+                "role": "user",
+                "content": "Short msg",
+                "timestamp": now_iso,
+                "token_count": 3,
+                "metadata": None,
+            })
+            for i in range(3)
+        ]
+
+        with (
+            patch(
+                "app.services.conversation_memory_service.redis_client"
+            ) as mock_redis,
+            patch(
+                "app.services.conversation_memory_service.get_settings"
+            ) as mock_settings,
+        ):
+            mock_settings.return_value.conversation_max_tokens = 50000
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "active",
+                    "message_count": "3",
+                    "total_tokens": "9",
+                    "created_at": now_iso,
+                    "last_activity_at": now_iso,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(return_value=None)
+            mock_redis.lrange = AsyncMock(return_value=msgs)
+
+            result = await svc.get_context_window("sess-123")
+
+        assert result.messages_included == 3
+        assert result.messages_summarized == 0
+
+    async def test_context_window_budget_exceeded(self) -> None:
+        """get_context_window should exclude oldest messages when over budget."""
+        svc = ConversationMemoryService()
+        now_iso = datetime.now(tz=UTC).isoformat()
+
+        # Create messages with large token counts
+        msgs = [
+            json.dumps({
+                "id": f"msg-{i}",
+                "role": "user",
+                "content": "x" * 400,  # ~100 tokens each
+                "timestamp": now_iso,
+                "token_count": 100,
+                "metadata": None,
+            })
+            for i in range(10)
+        ]
+
+        with (
+            patch(
+                "app.services.conversation_memory_service.redis_client"
+            ) as mock_redis,
+            patch(
+                "app.services.conversation_memory_service.get_settings"
+            ) as mock_settings,
+        ):
+            mock_settings.return_value.conversation_max_tokens = 50000
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "active",
+                    "message_count": "10",
+                    "total_tokens": "1000",
+                    "created_at": now_iso,
+                    "last_activity_at": now_iso,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(return_value=None)
+            mock_redis.lrange = AsyncMock(return_value=msgs)
+
+            # Set a small budget so only a few messages fit
+            result = await svc.get_context_window("sess-123", max_tokens=350)
+
+        assert result.messages_included < 10
+        assert result.messages_summarized > 0
+        assert result.total_tokens <= 350
+
+
+class TestSummarizeSession:
+    """Tests for ConversationMemoryService.summarize_session."""
+
+    async def test_summarize_auto_generated(self) -> None:
+        """summarize_session should generate truncation-based summary."""
+        svc = ConversationMemoryService()
+        now_iso = datetime.now(tz=UTC).isoformat()
+
+        msgs = [
+            json.dumps({
+                "id": "msg-1",
+                "role": "user",
+                "content": "Hello, how are you?",
+                "timestamp": now_iso,
+                "token_count": 5,
+                "metadata": None,
+            }),
+            json.dumps({
+                "id": "msg-2",
+                "role": "assistant",
+                "content": "I am fine, thank you!",
+                "timestamp": now_iso,
+                "token_count": 6,
+                "metadata": None,
+            }),
+        ]
+
+        with (
+            patch(
+                "app.services.conversation_memory_service.redis_client"
+            ) as mock_redis,
+            patch(
+                "app.services.conversation_memory_service.get_settings"
+            ) as mock_settings,
+        ):
+            mock_settings.return_value.conversation_ttl_seconds = 86400
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "active",
+                    "message_count": "2",
+                    "total_tokens": "11",
+                    "created_at": now_iso,
+                    "last_activity_at": now_iso,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(return_value=None)
+            mock_redis.lrange = AsyncMock(return_value=msgs)
+            mock_redis.set_cache = AsyncMock()
+            mock_redis.hset_field = AsyncMock()
+
+            result = await svc.summarize_session("sess-123")
+
+        assert result.session_id == "sess-123"
+        assert "user:" in result.summary
+        assert "assistant:" in result.summary
+        assert result.original_message_count == 2
+        assert result.original_token_count == 11
+        assert result.summary_token_count > 0
+        mock_redis.set_cache.assert_called_once()
+        mock_redis.hset_field.assert_called_once()
+
+    async def test_summarize_with_custom_text(self) -> None:
+        """summarize_session should use custom summary_text when provided."""
+        svc = ConversationMemoryService()
+        now_iso = datetime.now(tz=UTC).isoformat()
+
+        with (
+            patch(
+                "app.services.conversation_memory_service.redis_client"
+            ) as mock_redis,
+            patch(
+                "app.services.conversation_memory_service.get_settings"
+            ) as mock_settings,
+        ):
+            mock_settings.return_value.conversation_ttl_seconds = 86400
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "active",
+                    "message_count": "5",
+                    "total_tokens": "100",
+                    "created_at": now_iso,
+                    "last_activity_at": now_iso,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(return_value=None)
+            mock_redis.lrange = AsyncMock(return_value=[])
+            mock_redis.set_cache = AsyncMock()
+            mock_redis.hset_field = AsyncMock()
+
+            result = await svc.summarize_session(
+                "sess-123", summary_text="AI-generated summary"
+            )
+
+        assert result.summary == "AI-generated summary"
+
+
+class TestEndSession:
+    """Tests for ConversationMemoryService.end_session."""
+
+    async def test_end_active_session(self) -> None:
+        """end_session should create summary and clean up."""
+        svc = ConversationMemoryService()
+        now_iso = datetime.now(tz=UTC).isoformat()
+
+        with (
+            patch(
+                "app.services.conversation_memory_service.redis_client"
+            ) as mock_redis,
+            patch(
+                "app.services.conversation_memory_service.get_settings"
+            ) as mock_settings,
+        ):
+            mock_settings.return_value.conversation_ttl_seconds = 86400
+            mock_redis.hgetall = AsyncMock(
+                return_value={
+                    "session_id": "sess-123",
+                    "user_id": "user1",
+                    "project_id": "",
+                    "status": "active",
+                    "message_count": "3",
+                    "total_tokens": "50",
+                    "created_at": now_iso,
+                    "last_activity_at": now_iso,
+                }
+            )
+            mock_redis.get_cache = AsyncMock(return_value=None)
+            mock_redis.lrange = AsyncMock(return_value=[])
+            mock_redis.set_cache = AsyncMock()
+            mock_redis.hset_field = AsyncMock()
+            mock_redis.delete_key = AsyncMock(return_value=True)
+            mock_redis.srem = AsyncMock()
+
+            await svc.end_session("sess-123")
+
+        # Verify cleanup operations
+        mock_redis.hset_field.assert_called()
+        mock_redis.delete_key.assert_called_once()
+        mock_redis.srem.assert_called_once()
+
+    async def test_end_nonexistent_session_raises(self) -> None:
+        """end_session should raise SessionNotFoundError for missing session."""
+        svc = ConversationMemoryService()
+
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.hgetall = AsyncMock(return_value={})
+
+            with pytest.raises(SessionNotFoundError):
+                await svc.end_session("nonexistent")
+
+
+class TestGetUserSessions:
+    """Tests for ConversationMemoryService.get_user_sessions."""
+
+    async def test_get_user_sessions(self) -> None:
+        """get_user_sessions should return session IDs from Redis set."""
+        svc = ConversationMemoryService()
+
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.smembers = AsyncMock(
+                return_value={"sess-1", "sess-2", "sess-3"}
+            )
+
+            sessions = await svc.get_user_sessions("user1")
+
+        assert len(sessions) == 3
+        assert set(sessions) == {"sess-1", "sess-2", "sess-3"}
+
+    async def test_get_user_sessions_empty(self) -> None:
+        """get_user_sessions should return empty list for no sessions."""
+        svc = ConversationMemoryService()
+
+        with patch(
+            "app.services.conversation_memory_service.redis_client"
+        ) as mock_redis:
+            mock_redis.smembers = AsyncMock(return_value=set())
+
+            sessions = await svc.get_user_sessions("user1")
+
+        assert sessions == []

--- a/docs/pipeline/f6/f6-01-conversation-memory-redis-ses-architect.handoff.md
+++ b/docs/pipeline/f6/f6-01-conversation-memory-redis-ses-architect.handoff.md
@@ -1,0 +1,43 @@
+# Architect Handoff: Conversation Memory (Redis, Session Management)
+
+**Issue**: #37
+**Faz**: F6
+**Tarih**: 2026-03-03
+**Sonraki Agent**: developer
+
+## Ozet
+
+Konusma hafizasi sistemi (Layer 1). Redis ile oturum bazli kisa sureli hafiza yonetimi. Session CRUD, mesaj gecmisi, TTL otomatik temizlik, context window yonetimi (token limit) ve session ozet olusturma. Backend-only feature.
+
+## Feature Spec
+
+-> `shared/feature-specs/f6-37-f6-01-conversation-memory-redis-ses.md`
+
+## API Contracts
+
+-> `shared/api-contracts/rest/v1/conversation-memory.json`
+
+## Katman Dagilimi
+
+| Katman | Oncelik | Tahmini Dosya Sayisi |
+|--------|---------|---------------------|
+| backend | HIGH | 6 dosya (3 CREATE, 3 MODIFY) |
+| ios | N/A | 0 dosya |
+| agent | N/A | 0 dosya |
+
+## Dikkat Edilecekler
+
+- Mevcut `RedisClient` (`app/core/redis.py`) zaten temel conversation save/get/append/delete islemleri iceriyor. Yeni servis bunlarin uzerine insa etmeli, Redis key yapisini session bazli Hash + List + String olarak genisletmeli.
+- Mevcut `MemoryService` (`app/services/memory_service.py`) conversation layer'i icin `save_conversation`, `get_conversation`, `append_message`, `clear_conversation` metodlarini kullaniyor. Yeni `ConversationMemoryService` bunlari genisletecek ve session lifecycle yonetimi ekleyecek. Mevcut MemoryService'teki conversation metodlari yeni servise delege edilebilir.
+- Token hesaplama: karakter sayisi / 4 (yaklasik tahmin). Daha sonra tiktoken ile degistirilebilir.
+- Session ozeti icin Claude API cagirma. Summarize endpoint'i disaridan cagirilir; servis summary_text parametresi alarak ozeti Redis'e kaydeder. Gercek AI cagrisini orchestrator yapacak (bu issue kapsaminda degil). Simdilik basit bir truncation-based ozet kullanilabilir.
+- TTL: 24 saat varsayilan, konfigurasyondan degistirilebilir. Her mesaj eklendiginde TTL refresh edilir.
+- `docs/05_Memory_System_Specification.md` Bolum 3 (Conversation Memory) referans alinmali.
+- Bagimliliklarin durumu: F3-03 (Memory manager) zaten implement edilmis. Bu feature onu genisletiyor.
+
+## Dogrulama
+
+- [x] Feature spec yazildi
+- [x] API kontratlar olusturuldu
+- [x] Dosya sahipligi belirlendi
+- [x] Doc referanslari kontrol edildi

--- a/docs/pipeline/f6/f6-01-conversation-memory-redis-ses-developer.handoff.md
+++ b/docs/pipeline/f6/f6-01-conversation-memory-redis-ses-developer.handoff.md
@@ -1,0 +1,39 @@
+# Developer Handoff: Conversation Memory (Redis, Session Management)
+
+**Issue**: #37
+**Branch**: feature/f6/37-f6-01-conversation-memory-redis-ses
+**Tarih**: 2026-03-03
+**Sonraki Agent**: tester
+
+## Yapilan Degisiklikler
+
+| Dosya | Islem | Aciklama |
+|-------|-------|----------|
+| `apps/backend/app/schemas/conversation_memory.py` | CREATE | Pydantic domain entities ve request/response modelleri |
+| `apps/backend/app/services/conversation_memory_service.py` | CREATE | Session CRUD, mesaj yonetimi, ozet, context window servisi |
+| `apps/backend/app/api/routes/conversation_memory.py` | CREATE | REST endpoint'leri (7 endpoint) |
+| `apps/backend/app/core/redis.py` | MODIFY | Hash, List, Set, expire wrapper metodlari eklendi |
+| `apps/backend/app/core/config.py` | MODIFY | conversation_ttl_seconds ve conversation_max_tokens eklendi |
+| `apps/backend/app/core/exceptions.py` | MODIFY | ConflictError exception eklendi |
+| `apps/backend/app/main.py` | MODIFY | conversation_memory router eklendi |
+
+## API Kontrat Uyumu
+
+- Kontrat dosyasi: `shared/api-contracts/rest/v1/conversation-memory.json`
+- Dogrulanan endpoint sayisi: 7
+- Tum endpoint path, method, query param ve request/response field isimleri kontrata uygun
+
+## Dogrulama Sonuclari
+
+| Arac | Durum | Detay |
+|------|-------|-------|
+| ruff check | PASS | Tum dosyalar temiz |
+| ruff format | PASS | Tum dosyalar formatli |
+| mypy | PASS | Type check temiz |
+
+## Notlar
+
+- RedisClient'a wrapper metodlar eklendi (hset_mapping, hset_field, hgetall, rpush, llen, lrange, sadd, srem, smembers, expire, delete_key) - mypy type: ignore sadece redis-py stub uyumsuzluklari icin
+- Ozet olusturma: Basit truncation-based. Gercek AI ozeti orchestrator katmaninda yapilacak
+- Token hesaplama: karakter/4 yaklasimiyla. tiktoken daha sonra eklenebilir
+- ConflictError exception eklendi (session ended durumunda 409 donmek icin)

--- a/docs/pipeline/f6/f6-01-conversation-memory-redis-ses-reviewer.handoff.md
+++ b/docs/pipeline/f6/f6-01-conversation-memory-redis-ses-reviewer.handoff.md
@@ -1,0 +1,124 @@
+# Code Review: Conversation Memory (Redis, Session Management)
+
+**Issue**: #37
+**Reviewer**: agent:reviewer
+**Tarih**: 2026-03-03
+
+## Genel Degerlendirme
+
+ONAYLANDI
+
+Kod kalitesi yuksek, mimari standartlara uygun ve tum checklist maddeleri gecti. Conversation memory servisi dogru Redis veri yapilari (Hash, List, String, Set) kullanarak session lifecycle yonetimi sagliyor. Tum fonksiyonlar async, domain modeller frozen, type hint'ler eksiksiz ve structured logging kullaniliyor. Coverage %83 ile esik uzerinde.
+
+---
+
+## Duzeltilmesi Gereken (Blocker)
+
+Yok.
+
+---
+
+## Oneri (Non-blocker)
+
+### Token hesaplama iyilestirme
+**Dosya**: `apps/backend/app/services/conversation_memory_service.py:68-78`
+**Oneri**: `_estimate_tokens` fonksiyonu chars/4 yaklasimi kullaniyor. Gelecekte tiktoken entegrasyonu ile daha dogru token hesaplama yapilabilir. Mevcut yaklasim dokumante edilmis ve kabul edilebilir.
+
+### Unused import in routes
+**Dosya**: `apps/backend/app/api/routes/conversation_memory.py:148`
+**Oneri**: `get_settings` fonksiyon icinde import ediliyor (line 148). Bu calisir ancak module-level import tutarliligi icin dosya basina tasinabilir. Fonksiyonel bir sorun degil.
+
+---
+
+## Genel Notlar
+
+- Domain entity'ler (ConversationMessage, ConversationSession) `frozen=True` ile immutable
+- Tum service metodlari `async def` ile tanimlanmis
+- structlog kullaniliyor, stdlib logging yok
+- `Any` tipi hicbir yerde kullanilmamis
+- Redis islemleri RedisClient wrapper metodlari uzerinden yapiliyor (type safety)
+- Input validation Pydantic Field ile saglanmis (role regex pattern, content min/max length, limit/offset constraints)
+- Exception handling dogru: SessionNotFoundError -> NotFoundError (404), SessionEndedError -> ConflictError (409)
+- Error response'larda internal bilgi sizdirilmiyor (genel exception handler 500 donuyor)
+- Hardcoded secret/credential yok, tum config environment variable'lardan geliyor
+- API kontrat dosyasi (conversation-memory.json) ile tum 7 endpoint tam uyumlu
+
+## Checklist Ozeti
+
+| Kategori | Gecen | Kalan | Toplam |
+|----------|-------|-------|--------|
+| A. Python Kalite | 10/10 | 0/10 | 10 |
+| B. Swift Kalite | N/A | N/A | N/A |
+| C. Mimari | 8/8 | 0/8 | 8 |
+| D. Guvenlik | 10/10 | 0/10 | 10 |
+| E. Test | 8/8 | 0/8 | 8 |
+| **Toplam** | **36/36** | **0/36** | **36** |
+
+### A. Python Kod Kalitesi
+
+| # | Kontrol | Durum | Not |
+|---|---------|-------|-----|
+| A1 | Type hint'ler | PASS | Tum fonksiyon ve parametre type hint'leri mevcut |
+| A2 | `Any` tipi yok | PASS | Hicbir public API'da `Any` yok |
+| A3 | Async pattern | PASS | Tum service ve route fonksiyonlari `async def` |
+| A4 | Frozen domain modeller | PASS | ConversationMessage ve ConversationSession `frozen=True` |
+| A5 | Exception handling | PASS | Custom exception hierarchy + dogru HTTP mapping |
+| A6 | structlog | PASS | Tum dosyalarda structlog kullaniliyor |
+| A7 | Import sirasi | PASS | stdlib -> 3rd party -> local sirasi korunuyor |
+| A8 | DB erisim katmani | PASS | Redis erisimi RedisClient wrapper uzerinden |
+| A9 | Ruff check | PASS | Tester handoff'ta dogrulandi |
+| A10 | MyPy strict | PASS | Tester handoff'ta dogrulandi |
+
+### C. Mimari Uyumluluk
+
+| # | Kontrol | Durum | Not |
+|---|---------|-------|-----|
+| C1 | WebSocket format | N/A | Bu feature WS mesaj tipi eklemiyor |
+| C2 | Tool tanimlari | N/A | Bu feature tool eklememiyor |
+| C3 | iOS ekran yapisi | N/A | Sadece backend katmani |
+| C4 | Memory sistemi | PASS | docs/05 ile uyumlu - Layer 1 (conversation) |
+| C5 | Guvenlik matrisi | PASS | Input validation mevcut |
+| C6 | Agent protokolu | N/A | Agent katmani etkilenmemis |
+| C7 | API kontrat uyumu | PASS | 7/7 endpoint kontrata tam uyumlu (path, method, params, request/response) |
+| C8 | Feature spec dosya listesi | PASS | Tum beklenen dosyalar olusturulmus |
+
+### D. Guvenlik
+
+| # | Kontrol | Durum | Not |
+|---|---------|-------|-----|
+| D1 | SQL injection | N/A | SQL kullanilmiyor (Redis only) |
+| D2 | Sensitive data log | PASS | Log'larda sadece session_id, user_id, token_count var |
+| D3 | Shell runner | N/A | Shell komutu calistirilmiyor |
+| D4 | JWT Keychain | N/A | iOS katmani yok |
+| D5 | TLS 1.3 | N/A | Transport katmani degistirilmemis |
+| D6 | Input validation | PASS | Pydantic Field ile role, content, limit, offset, ttl_seconds dogrulaniyor |
+| D7 | Rate limiting | PASS | Mevcut RateLimitMiddleware aktif |
+| D8 | CORS | PASS | Mevcut CORS config degistirilmemis |
+| D9 | Hardcoded secret | PASS | Tum config env variable'lardan |
+| D10 | Error info leak | PASS | Genel exception handler internal bilgi sizmaz |
+
+### E. Test ve Coverage
+
+| # | Kontrol | Durum | Not |
+|---|---------|-------|-----|
+| E1 | Unit test | PASS | 24 unit test, 8 test sinifi |
+| E2 | Integration test | PASS | 8 integration test |
+| E3 | Coverage esik | PASS | %83 >= %80 |
+| E4 | Edge case'ler | PASS | Bos session, ended session, gecersiz role, gecersiz limit/offset, bos liste, truncation |
+| E5 | Mock kullanimi | PASS | Redis client mock edilmis (dis bagimlilk) |
+| E6 | Test isimleri | PASS | Aciklayici ve tutarli isimlendirme |
+| E7 | Flaky risk | PASS | Zaman bagimli test yok, mock ile izole |
+| E8 | Kontrat testleri | PASS | 3 kontrat testi (file exists, endpoints registered, count matches) |
+
+## Pipeline Durum
+
+| Adim | Agent | Durum |
+|------|-------|-------|
+| Architect | architect | DONE |
+| Developer | developer | DONE |
+| Tester | tester | DONE |
+| Reviewer | reviewer | DONE (ONAYLANDI) |
+
+## Sonraki Adim
+
+ONAYLANDI: PR merge edilebilir.

--- a/docs/pipeline/f6/f6-01-conversation-memory-redis-ses-tester.handoff.md
+++ b/docs/pipeline/f6/f6-01-conversation-memory-redis-ses-tester.handoff.md
@@ -1,0 +1,51 @@
+# Tester Handoff: Conversation Memory (Redis, Session Management)
+
+**Issue**: #37
+**Branch**: feature/f6/37-f6-01-conversation-memory-redis-ses
+**Tarih**: 2026-03-03
+**Sonraki Agent**: reviewer
+
+## Coverage Raporu
+
+| Platform | Coverage % | Esik | Durum |
+|----------|-----------|------|-------|
+| Backend (app/) | 83% | >= 80% | PASS |
+| iOS (RafRaf/) | N/A | N/A | N/A |
+| Agent (agent/) | N/A | N/A | N/A |
+
+## Yazilan Testler
+
+### Backend
+| Test Dosyasi | Test Sayisi | Basarili | Basarisiz |
+|-------------|-------------|----------|-----------|
+| tests/unit/test_services/test_conversation_memory_service.py | 24 | 24 | 0 |
+| tests/integration/test_api/test_conversation_memory_endpoints.py | 8 | 8 | 0 |
+| tests/contract/test_conversation_memory_contract.py | 3 | 3 | 0 |
+| **Toplam** | **35** | **35** | **0** |
+
+## Kontrat Test Sonuclari
+
+| Platform | Kontrat Dosyasi | Test Sayisi | Durum |
+|----------|----------------|-------------|-------|
+| Backend | conversation-memory.json | 3 | PASS |
+
+## Mock Kullanimi
+
+| Mock | Neden |
+|------|-------|
+| redis_client (RedisClient) | Unit testlerde Redis baglantisi yerine mock. Dis bagimlilk (Redis sunucu), test izolasyonu icin mock edildi |
+
+## Edge Case'ler
+
+- Bos session_id ile get_session -> SessionNotFoundError
+- Ended session'a mesaj ekleme -> SessionEndedError
+- Gecersiz role ile mesaj ekleme -> 422 validation error
+- Gecersiz limit/offset parametreleri -> 422 validation error
+- Bos kullanici sessions listesi -> bos liste
+- Context window butcesi asildiktan sonra eski mesajlari haric birakma
+- Ozet metin truncation (2000 karakter limiti)
+
+## Bilinen Sorunlar
+
+- 12 pre-existing test failure (auth/security ile ilgili, bu feature'dan bagimsiz)
+- Yeni conversation memory testleri 100% basarili (35/35)

--- a/shared/api-contracts/rest/v1/conversation-memory.json
+++ b/shared/api-contracts/rest/v1/conversation-memory.json
@@ -1,0 +1,380 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ConversationMemoryEndpoints",
+  "description": "Conversation memory (Redis, session management) REST API kontrati",
+  "endpoints": [
+    {
+      "method": "POST",
+      "path": "/api/v1/conversations",
+      "description": "Yeni conversation session olustur",
+      "requestBody": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "description": "Kullanici kimlik bilgisi"
+          },
+          "project_id": {
+            "type": "string",
+            "description": "Opsiyonel proje ID (UUID formatinda)"
+          },
+          "ttl_seconds": {
+            "type": "integer",
+            "minimum": 60,
+            "maximum": 172800,
+            "description": "Session TTL suresi (saniye). Varsayilan: 86400 (24 saat)"
+          }
+        },
+        "required": ["user_id"],
+        "additionalProperties": false
+      },
+      "responseBody": {
+        "type": "object",
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Olusturulan session ID"
+          },
+          "user_id": {
+            "type": "string",
+            "description": "Kullanici ID"
+          },
+          "project_id": {
+            "type": "string",
+            "description": "Proje ID (varsa)"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["active", "ended", "summarized"],
+            "description": "Session durumu"
+          },
+          "message_count": {
+            "type": "integer",
+            "description": "Toplam mesaj sayisi"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Toplam token sayisi"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Olusturulma zamani (ISO 8601)"
+          },
+          "last_activity_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Son aktivite zamani"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Session ozeti (varsa)"
+          }
+        },
+        "required": ["session_id", "user_id", "status", "message_count", "total_tokens", "created_at"]
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/conversations/{session_id}",
+      "description": "Session bilgisi getir",
+      "queryParams": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "responseBody": {
+        "type": "object",
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Session ID"
+          },
+          "user_id": {
+            "type": "string",
+            "description": "Kullanici ID"
+          },
+          "project_id": {
+            "type": "string",
+            "description": "Proje ID (varsa)"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["active", "ended", "summarized"],
+            "description": "Session durumu"
+          },
+          "message_count": {
+            "type": "integer",
+            "description": "Toplam mesaj sayisi"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Toplam token sayisi"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Olusturulma zamani"
+          },
+          "last_activity_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Son aktivite zamani"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Session ozeti (varsa)"
+          }
+        },
+        "required": ["session_id", "user_id", "status", "message_count", "total_tokens", "created_at"]
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/v1/conversations/{session_id}",
+      "description": "Session sonlandir (ozet olustur, temizle)"
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/conversations/{session_id}/messages",
+      "description": "Mesaj gecmisi getir",
+      "queryParams": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "description": "Maksimum mesaj sayisi (varsayilan: 50)"
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Baslangic pozisyonu (varsayilan: 0)"
+          }
+        },
+        "additionalProperties": false
+      },
+      "responseBody": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Mesaj ID"
+                },
+                "role": {
+                  "type": "string",
+                  "enum": ["user", "assistant", "tool", "system"],
+                  "description": "Mesaj rolu"
+                },
+                "content": {
+                  "type": "string",
+                  "description": "Mesaj icerigi"
+                },
+                "timestamp": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Mesaj zamani"
+                },
+                "token_count": {
+                  "type": "integer",
+                  "description": "Mesaj token sayisi"
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "Opsiyonel ek bilgiler"
+                }
+              },
+              "required": ["id", "role", "content", "timestamp", "token_count"]
+            },
+            "description": "Mesaj listesi"
+          },
+          "total": {
+            "type": "integer",
+            "description": "Toplam mesaj sayisi"
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "Daha fazla mesaj var mi"
+          }
+        },
+        "required": ["messages", "total", "has_more"]
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/conversations/{session_id}/messages",
+      "description": "Mesaj ekle",
+      "requestBody": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": ["user", "assistant", "tool", "system"],
+            "description": "Mesaj rolu"
+          },
+          "content": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100000,
+            "description": "Mesaj icerigi"
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Opsiyonel ek bilgiler (ornegin model_used, tool_call_id)"
+          }
+        },
+        "required": ["role", "content"],
+        "additionalProperties": false
+      },
+      "responseBody": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Mesaj ID"
+          },
+          "role": {
+            "type": "string",
+            "enum": ["user", "assistant", "tool", "system"],
+            "description": "Mesaj rolu"
+          },
+          "content": {
+            "type": "string",
+            "description": "Mesaj icerigi"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Mesaj zamani"
+          },
+          "token_count": {
+            "type": "integer",
+            "description": "Mesaj token sayisi"
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Ek bilgiler"
+          },
+          "context_window_usage": {
+            "type": "object",
+            "properties": {
+              "total_tokens": {
+                "type": "integer",
+                "description": "Toplam token sayisi"
+              },
+              "max_tokens": {
+                "type": "integer",
+                "description": "Maksimum token limiti"
+              },
+              "usage_percent": {
+                "type": "number",
+                "description": "Kullanim yuzdesi"
+              }
+            },
+            "description": "Context window kullanim durumu"
+          }
+        },
+        "required": ["id", "role", "content", "timestamp", "token_count"]
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/conversations/{session_id}/summarize",
+      "description": "Session ozetini olustur",
+      "responseBody": {
+        "type": "object",
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Session ID"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Olusturulan ozet metni"
+          },
+          "original_message_count": {
+            "type": "integer",
+            "description": "Ozetlenen mesaj sayisi"
+          },
+          "original_token_count": {
+            "type": "integer",
+            "description": "Ozetlenen toplam token sayisi"
+          },
+          "summary_token_count": {
+            "type": "integer",
+            "description": "Ozet token sayisi"
+          }
+        },
+        "required": ["session_id", "summary", "original_message_count", "original_token_count", "summary_token_count"]
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/conversations/{session_id}/context",
+      "description": "Context window icin optimize edilmis mesaj gecmisi",
+      "queryParams": {
+        "type": "object",
+        "properties": {
+          "max_tokens": {
+            "type": "integer",
+            "minimum": 1000,
+            "maximum": 100000,
+            "description": "Maksimum token limiti (varsayilan: 50000)"
+          }
+        },
+        "additionalProperties": false
+      },
+      "responseBody": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "role": {
+                  "type": "string",
+                  "description": "Mesaj rolu"
+                },
+                "content": {
+                  "type": "string",
+                  "description": "Mesaj icerigi"
+                }
+              },
+              "required": ["role", "content"]
+            },
+            "description": "Context window icin kesilmis mesaj listesi"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Eski mesajlarin ozeti (varsa)"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Toplam context token sayisi"
+          },
+          "messages_included": {
+            "type": "integer",
+            "description": "Dahil edilen mesaj sayisi"
+          },
+          "messages_summarized": {
+            "type": "integer",
+            "description": "Ozetlenen mesaj sayisi"
+          }
+        },
+        "required": ["messages", "total_tokens", "messages_included", "messages_summarized"]
+      }
+    }
+  ]
+}

--- a/shared/feature-specs/f6-37-f6-01-conversation-memory-redis-ses.md
+++ b/shared/feature-specs/f6-37-f6-01-conversation-memory-redis-ses.md
@@ -1,0 +1,133 @@
+# Feature: Conversation Memory (Redis, Session Management)
+
+**Issue**: #37
+**Faz**: F6
+**Katmanlar**: backend
+**Pipeline**: full
+**Tarih**: 2026-03-03
+
+## Ozet
+
+Konusma hafizasi sistemi. Redis ile oturum bazli kisa sureli hafiza yonetimi saglar. Her konusma oturumu Redis'te saklanir, mesajlar eklenir/okunur ve TTL ile otomatik temizlenir. Uzun konusmalarda context window yonetimi (token limit) ve oturum ozeti olusturma destegi saglar. Bu ozellik, AI'nin mevcut konusmadaki baglami korumasini ve "az once soyledigim" gibi referanslari anlamasini saglar.
+
+## Degisecek Dosyalar
+
+### Backend (`apps/backend/`)
+
+| Dosya | Islem | Aciklama |
+|-------|-------|----------|
+| `app/services/conversation_memory_service.py` | CREATE | Conversation memory business logic (session CRUD, mesaj yonetimi, ozet, context window) |
+| `app/schemas/conversation_memory.py` | CREATE | Pydantic request/response modelleri (session, mesaj, ozet) |
+| `app/api/routes/conversation_memory.py` | CREATE | REST endpoint'leri (session CRUD, mesaj gecmisi, ozet) |
+| `app/core/redis.py` | MODIFY | Session metadata, mesaj listesi (RPUSH), TTL refresh, session ozet cache |
+| `app/core/config.py` | MODIFY | Conversation memory konfigurasyonu (TTL, max tokens, max messages) |
+| `app/main.py` | MODIFY | Yeni router'i dahil et |
+
+## API Endpoints
+
+### REST
+
+| Method | Path | Request | Response | Aciklama |
+|--------|------|---------|----------|----------|
+| POST | `/api/v1/conversations` | `ConversationCreateRequest` | `ConversationSessionResponse` | Yeni session olustur |
+| GET | `/api/v1/conversations/{session_id}` | - | `ConversationSessionResponse` | Session bilgisi getir |
+| DELETE | `/api/v1/conversations/{session_id}` | - | 204 | Session sonlandir (ozet olustur, temizle) |
+| GET | `/api/v1/conversations/{session_id}/messages` | `?limit=&offset=` | `ConversationMessagesResponse` | Mesaj gecmisi getir |
+| POST | `/api/v1/conversations/{session_id}/messages` | `ConversationMessageCreateRequest` | `ConversationMessageResponse` | Mesaj ekle |
+| POST | `/api/v1/conversations/{session_id}/summarize` | - | `ConversationSummaryResponse` | Session ozetini olustur |
+| GET | `/api/v1/conversations/{session_id}/context` | `?max_tokens=` | `ConversationContextResponse` | Context window icin optimize edilmis mesaj gecmisi |
+
+### WebSocket Messages
+
+Bu feature WS mesaj tipi eklemez. Mevcut WS handler, session_id bazli mesaj alip conversation_memory_service araciligiyla Redis'e kaydeder. Bu entegrasyon gelecek bir WS handler update'inde yapilacaktir.
+
+## Data Model
+
+### Redis Veri Yapilari
+
+Session metadata (Hash):
+```
+conv:session:{session_id}:meta -> {user_id, project_id, created_at, status, message_count, total_tokens}
+```
+
+Mesaj listesi (List - RPUSH):
+```
+conv:session:{session_id}:messages -> [msg1_json, msg2_json, ...]
+```
+
+Session ozeti (String):
+```
+conv:session:{session_id}:summary -> "ozet metni"
+```
+
+Kullanici aktif sessionlari (Set):
+```
+conv:user:{user_id}:sessions -> {session_id_1, session_id_2, ...}
+```
+
+### Pydantic Models
+
+```python
+class ConversationMessage(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    role: str  # "user" | "assistant" | "tool" | "system"
+    content: str
+    timestamp: datetime
+    token_count: int
+    metadata: dict[str, str] | None = None
+
+
+class ConversationSession(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    session_id: str
+    user_id: str
+    project_id: str | None = None
+    status: str  # "active" | "ended" | "summarized"
+    message_count: int
+    total_tokens: int
+    created_at: datetime
+    last_activity_at: datetime | None = None
+    summary: str | None = None
+```
+
+## Business Rules
+
+1. Session olusturulurken user_id zorunlu, project_id opsiyonel
+2. Her session'in TTL'i 24 saat (konfigurasyondan degistirilebilir)
+3. Her mesaj eklendiginde TTL yenilenir (session aktif kaldikca silimez)
+4. Context window esigi: 50,000 token (konfigurasyondan degistirilebilir)
+5. Esik asildiginda eski mesajlar ozetlenir ve ozet session'a kaydedilir
+6. Session sonlandirildiginda: ozet olusturulur, Redis'teki cache temizlenir (ozet haric)
+7. Mesaj listesi RPUSH ile eklenir (siralama korunur), LRANGE ile okunur
+8. Token hesaplama: karakter sayisi / 4 (yaklasik tahmin)
+9. Session ID formatı: UUID v4
+10. 30 dakika inaktivite sonrasi session "stale" olarak isaretlenir (TTL ile otomatik temizlik)
+
+## Test Requirements
+
+### Backend
+- [ ] Unit test: ConversationMemoryService.create_session — session olusturma
+- [ ] Unit test: ConversationMemoryService.add_message — mesaj ekleme ve token hesaplama
+- [ ] Unit test: ConversationMemoryService.get_messages — mesaj gecmisi (limit/offset)
+- [ ] Unit test: ConversationMemoryService.get_context_window — context window kesme
+- [ ] Unit test: ConversationMemoryService.summarize_session — ozet olusturma
+- [ ] Unit test: ConversationMemoryService.end_session — session sonlandirma
+- [ ] Unit test: TTL yenileme (her mesaj ekleme sonrasi)
+- [ ] Unit test: Token limit asimi durumunda ozet olusturma tetiklenmesi
+- [ ] Integration test: Redis ile tam CRUD dongusu
+- [ ] Integration test: REST endpoint'ler (session create, message add, get context)
+- [ ] Integration test: TTL expiry davranisi
+
+## Acceptance Criteria
+
+- [ ] Redis ile conversation storage calisiyor
+- [ ] Session olusturma/sonlandirma calisiyor
+- [ ] Mesaj gecmisi kaydetme/okuma calisiyor
+- [ ] TTL ile otomatik temizlik calisiyor
+- [ ] Context window yonetimi (token limit) calisiyor
+- [ ] Session ozeti olusturma (uzun konusmalarda) calisiyor
+- [ ] Unit + integration testler yazildi
+- [ ] Coverage >= 80%


### PR DESCRIPTION
## Summary

- Redis-based conversation memory service with full session lifecycle (create, get, end)
- Message storage with RPUSH/LRANGE, context window management (token budget limiting), and session summarization
- 7 REST endpoints matching API contract (`shared/api-contracts/rest/v1/conversation-memory.json`)
- RedisClient wrapper methods for type-safe Redis operations (Hash, List, Set, String)

## Changes

| File | Action | Description |
|------|--------|-------------|
| `apps/backend/app/schemas/conversation_memory.py` | CREATE | Pydantic domain entities (frozen) + request/response schemas |
| `apps/backend/app/services/conversation_memory_service.py` | CREATE | Session CRUD, message management, summarization, context window |
| `apps/backend/app/api/routes/conversation_memory.py` | CREATE | 7 REST endpoints |
| `apps/backend/app/core/redis.py` | MODIFY | 12 wrapper methods (hset_mapping, hgetall, rpush, lrange, etc.) |
| `apps/backend/app/core/config.py` | MODIFY | conversation_ttl_seconds, conversation_max_tokens settings |
| `apps/backend/app/core/exceptions.py` | MODIFY | ConflictError (409) exception added |
| `apps/backend/app/main.py` | MODIFY | conversation_memory router included |
| `shared/feature-specs/f6-37-*.md` | CREATE | Feature specification |
| `shared/api-contracts/rest/v1/conversation-memory.json` | CREATE | API contract (7 endpoints) |

## Pipeline

| Step | Agent | Status |
|------|-------|--------|
| Architect | agent:architect | DONE |
| Developer | agent:developer | DONE |
| Tester | agent:tester | DONE (35/35 tests, 83% coverage) |
| Reviewer | agent:reviewer | DONE (ONAYLANDI, 36/36 checklist) |

## Test plan

- [x] Unit tests: 24 tests (service layer - create, get, add message, get messages, context window, summarize, end, user sessions)
- [x] Integration tests: 8 tests (REST endpoints - success/validation/404 scenarios)
- [x] Contract tests: 3 tests (file exists, all endpoints registered, endpoint count)
- [x] Coverage: 83% (threshold: 80%)
- [x] ruff check: PASS
- [x] mypy strict: PASS

Closes #37