### PR TITLE
feat(ios): Add Xcode project for simulator builds

### DIFF
--- a/apps/ios/RafRaf.xcodeproj/project.pbxproj
+++ b/apps/ios/RafRaf.xcodeproj/project.pbxproj
@@ -1,0 +1,3472 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0094D3ECB7DE3EDD40CFCA6E /* RFTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9494F1BB2D75D74A4D23360 /* RFTextTests.swift */; };
+		00A429AD9984993125CFFE5F /* KeychainHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0311D62510D1BCEA61F04553 /* KeychainHelperTests.swift */; };
+		00E71759402C5B52C67BE896 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F503BC69A6F011BBD9C5C7A1 /* ChatView.swift */; };
+		01719DC9951AE7891BDD95E0 /* RFSettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629C0C741A2EA1DCC248E89B /* RFSettingsRow.swift */; };
+		022E4B32DEA2F3ED740BF4C0 /* RFCountdownTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E90391D47DE86AFCDF0FE1D /* RFCountdownTimer.swift */; };
+		03A0DAF73C6811B082C60CE9 /* ApprovalQuestionDTOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88476BCA795924931C66A42B /* ApprovalQuestionDTOTests.swift */; };
+		0486617591AA9DC73CCD5E40 /* VoiceAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9451177087744E75E0DBE274 /* VoiceAudioPlayer.swift */; };
+		04DC8756C530779C225AE8E4 /* FileDTOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3260EBF20616C55A22A28A /* FileDTOTests.swift */; };
+		05A157E836252BF2B965C678 /* VoiceOutputTestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9425CF331038E45CABFF6BFE /* VoiceOutputTestFactory.swift */; };
+		06008B1B10A0C4CEBF73A731 /* TTSAudioResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07256F747ADB59F141BD6018 /* TTSAudioResult.swift */; };
+		0883540B6F520BF888F35BCC /* PushNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C93280E1D8CE2C3ED37AB6 /* PushNotificationManager.swift */; };
+		088F92D188D922C2A6858E32 /* ScreenshotDTOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD7EB1A7F663F2AE599276F /* ScreenshotDTOTests.swift */; };
+		08A0A6FEFD4129A9250D7D4F /* DeepgramMessageDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA1AB7899F9DFDFABB9E7A4 /* DeepgramMessageDTO.swift */; };
+		09031E9D7E761B47D391B82A /* RFAudioSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839DFFD5CDFE6D3EA5CC1B8A /* RFAudioSessionManager.swift */; };
+		09726529F6A1DE96A4264DF8 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012C760BCD578912C69FF278 /* UserProfile.swift */; };
+		09A8C98AF09920405C772997 /* ProgressModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5224B55A7BB421788157E25 /* ProgressModelTests.swift */; };
+		09FD1381D6990FAC0EFC2906 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A7CF6BE6C6D35BDCF28F53 /* ChatViewModel.swift */; };
+		0B3BA88DE6894D76EA3165AF /* ObserveProgressUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844C2FAAA839BD62A7A4E1F4 /* ObserveProgressUseCase.swift */; };
+		0C016A0096A0AE5F1DD742AE /* HandleNotificationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA00A07C3581E3EFC1510B0 /* HandleNotificationUseCase.swift */; };
+		0C8730146DEE46F8798954CF /* TTSRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D34BFB48FE8E9FCA8D65AA6 /* TTSRequestDTO.swift */; };
+		0CA7B086A2C39B8BD75EFC89 /* SynthesizeSpeechUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14699F016E8A261A536C426 /* SynthesizeSpeechUseCase.swift */; };
+		0DAD8D681D8992E3C0C0A6B6 /* ScreenshotRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C7199300B4BE5F1DB5D5A /* ScreenshotRepositoryProtocol.swift */; };
+		0FB1D09FEFE6438C1855DAEA /* ProjectDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45410A8C9586B7AC9E5F0343 /* ProjectDTO.swift */; };
+		12AA105F2ED968F9FB79B868 /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28FA43D580A4C8DCD750BFD /* NetworkClient.swift */; };
+		132C7631415CBB0529872367 /* NotificationRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2DD85745706E339B58077A /* NotificationRepositoryProtocol.swift */; };
+		13C90BACF6044E45AED79F36 /* VoiceInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF111423ECD9DF6A6D28803 /* VoiceInputViewModelTests.swift */; };
+		170305E3526BE2CD9BE0A789 /* ApprovalQuestionDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5B2EDFD388B80900006C19 /* ApprovalQuestionDTO.swift */; };
+		180CE160ABC188916E202F40 /* RegisterDeviceTokenUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E9B6A86D86A85928EC43D4 /* RegisterDeviceTokenUseCase.swift */; };
+		1A3BFE87C89518227FA52615 /* RFEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B14A5823261777D9A44ECCE /* RFEmptyStateView.swift */; };
+		1BDC516014CF53D3C0701DFF /* RFLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371ADE781BE1D773A3E1CD89 /* RFLoginView.swift */; };
+		1CC9608784807ECCA5328745 /* ChatAttachmentDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5A0CEEA28B2E01F3408A9A /* ChatAttachmentDTO.swift */; };
+		1D1157B17E827FDD41E0ABE1 /* MockAuthRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00D12AD59FE69B29E947D16 /* MockAuthRepository.swift */; };
+		1E0E7D6B3EF5707969CD553F /* RFSpacingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C50619DD04EF18D55CB97E /* RFSpacingTests.swift */; };
+		1E7221F3B2129D72AC349A25 /* SendMessageUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93269E459ED3188CC38BD6A0 /* SendMessageUseCaseTests.swift */; };
+		1EA2E5E7AFDEC784ACCBE7C8 /* ProgressTestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3EBF23EE03D49A6FCB28F2 /* ProgressTestFactory.swift */; };
+		1F6B0659DFC3BF6BF7FA3D8A /* ScreenshotDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DD4187290AB38FC00C47889 /* ScreenshotDTO.swift */; };
+		2082D7617DDDD3948E276962 /* ProgressState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BC517FE8F386693CAEE3FF /* ProgressState.swift */; };
+		20E1E60883F05FDD047D6558 /* RFVoiceSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BAA8A08BABA9E6CCBB3CC5 /* RFVoiceSelector.swift */; };
+		212C0308EE8AEA87A1C5B4B0 /* Screenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB47CD519D01037848C453D /* Screenshot.swift */; };
+		22A5ABD1132ACBFA8D792AB9 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA104FEB0FD2EFD04B0CD61 /* Project.swift */; };
+		23195AD5A4759668886E49F0 /* UserRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918A3F002FFBE2BE8D9EB4F5 /* UserRepositoryProtocol.swift */; };
+		23771195AC45B562E87C90EE /* ScreenshotViewerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F03CE4C7201D9AFD3FA1D1 /* ScreenshotViewerViewModelTests.swift */; };
+		23DDF59C55AA208C878A40FC /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C365DE11989085900D374D8 /* KeychainHelper.swift */; };
+		246C5412E373E052423CDFE2 /* RFCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873A95A473C0B0BC9B36ACED /* RFCardTests.swift */; };
+		25523C8B1BFFE6EF66C8222D /* RFFilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDAA4E5F9C097B9A0DCD3ED /* RFFilePreviewView.swift */; };
+		2C86C4C06F663280FAD125AB /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363B74F897CDBED36B83D849 /* ProgressView.swift */; };
+		2C934D278CD3A23533150EBD /* NotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073B5D01B9C1C155E7F5A50C /* NotificationRouter.swift */; };
+		2D63E129E0C52CE9E2F2DC3F /* RFAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822D1B3519782E19AAE6B807 /* RFAvatar.swift */; };
+		2DA861BF0D903CCBEF2917A8 /* GetProjectsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FADD172BD04821AA0F68F16 /* GetProjectsUseCase.swift */; };
+		2DD8447B16F1E049005D1493 /* RFSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B5C79F81BBBAB0FC37BF61 /* RFSpacing.swift */; };
+		2F231408FDDB60ABCC215B2D /* ApprovalCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E123D689391F5EDCB9E1D919 /* ApprovalCardViewModelTests.swift */; };
+		2F3AF5D31BC16ADB2632C01E /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D0B1722F9261441B62830E /* AppLogger.swift */; };
+		2F9CFBF1478CCE71325589B6 /* RFApprovalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EFD5ABF35F2A79B997B8A09 /* RFApprovalCard.swift */; };
+		30FA7696EA507B83ACF694B7 /* MockVoiceInputRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA37EB0CDF96E19A3DECC86 /* MockVoiceInputRepository.swift */; };
+		324142A3F5FBEDC5DB58AE01 /* ApprovalQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCE0E6590187D6D085DD904 /* ApprovalQuestion.swift */; };
+		32657889244D50961E14014B /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975ABDD02BBE17015B5B12B8 /* SettingsViewModel.swift */; };
+		32E0335FCFB1EE2A2B21FA7A /* DownloadFileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F113CB582E1708646DC09D /* DownloadFileUseCase.swift */; };
+		33352F715A9A777C09D806C7 /* ScreenshotModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207A34477514118FB3C20E6C /* ScreenshotModelTests.swift */; };
+		35A0D790EAD344C13F946454 /* AppTabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6500E42A1EC1502F70F2EFB /* AppTabTests.swift */; };
+		35A9D0F7A2B7F2F954DDB024 /* ApprovalResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19403B092F47DC09ADF90B3 /* ApprovalResponseDTO.swift */; };
+		374B87F946F37A59FC330A8C /* RFApprovalOptionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D27E77CD6F518CFAFDCBEF2 /* RFApprovalOptionButton.swift */; };
+		39528FF437D4E8F29DE73A67 /* ScreenshotViewerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A066A9189723C78D76BD8E1 /* ScreenshotViewerViewModel.swift */; };
+		395D1A871FD58CBB420430A1 /* LoginUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2D79F44187942A602731BB /* LoginUseCaseTests.swift */; };
+		397062E55ADD9D6034FFAC6C /* AppSettingsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919770F140B17FDB577BAC91 /* AppSettingsModelTests.swift */; };
+		3A38E7A682E185774E6519D7 /* ProjectDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE63BB82B0AF956CDD1A5B38 /* ProjectDetailViewModel.swift */; };
+		3ABA5BF8EB9D9235CA41BD2D /* RFButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6378F006F2E44C0E575BBC /* RFButton.swift */; };
+		3BA9D7B80DD0640E82CCAF06 /* ProjectStatusDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F6D7D2C0636983F1E7E31A /* ProjectStatusDTO.swift */; };
+		3D8C1E1CB0832C4FDA0E5639 /* FileMetadataDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFD733653E0525C72ACFCB1 /* FileMetadataDTO.swift */; };
+		3E11FD135C45C3D984211CD4 /* NotificationMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187375870FE1385F61CC29DA /* NotificationMapperTests.swift */; };
+		3EC7B34BB24C56D3DD16B465 /* ProgressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA6E443317BC57250C82113 /* ProgressViewModel.swift */; };
+		42B5E3AB236F1D7B479D4AE6 /* RFChatInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0617A5997B3B90CE3D2AE134 /* RFChatInput.swift */; };
+		4340763335A59253756E7E95 /* RFStepProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D286048B24F11048FAA30AA5 /* RFStepProgressView.swift */; };
+		43AD14D68F6F2B2A3CBA4503 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5992E0A0F127905160F54939 /* AppSettings.swift */; };
+		4411C8B0224B50F3D8722FB8 /* ChatMessageMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7561424D168B690C0D88BA1 /* ChatMessageMapper.swift */; };
+		4425A8A8C5B2A44E05602D67 /* ScreenshotMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2D1ED44EF7C4C281C1C692 /* ScreenshotMapperTests.swift */; };
+		44864A3B0FFC3FB5DE6A680A /* BiometricLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F6A7FF298FF847CDAE8333 /* BiometricLoginUseCase.swift */; };
+		4555097283E4374AA064D72F /* TTSAudioResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1776AD17EDD35DB4E0121C58 /* TTSAudioResultTests.swift */; };
+		455C6DB50B6837B34717A760 /* RFErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73EDDECB3A8862452651E8E2 /* RFErrorView.swift */; };
+		45601D37FEEA39D7808D30AA /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1BED62AE03EC1F750E0D07 /* WebSocketClient.swift */; };
+		466CA6F0C0CD819EFFE6D1B7 /* RFTranscriptionOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C400ADD3AA001DA1105EBDDC /* RFTranscriptionOverlay.swift */; };
+		47CCE3B260AF692FAA7606CA /* ScreenshotTestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EDD58FB04BAB8CFFBF18E2 /* ScreenshotTestFactory.swift */; };
+		483B69F197C7E5E3605B0CE6 /* RFProjectCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60848B934A2BFAEBE6FBD0F /* RFProjectCard.swift */; };
+		48D6EDC37627B786BA0C66B6 /* ApprovalRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B7498BA91A02D08B6CA590 /* ApprovalRepositoryProtocol.swift */; };
+		494E791ED2621314109FC9AA /* RFToolStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D3D086D405CEE09599451F /* RFToolStatusView.swift */; };
+		4B9D07E2290FA0285043EB11 /* AuthModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFAFAD24416A098AFFD9D60C /* AuthModels.swift */; };
+		4F574BB1C3C518704E93FE30 /* SettingsRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B841E5C35A563010F7F8A41 /* SettingsRepositoryImplTests.swift */; };
+		4F6B9B9399A69F6315EB7431 /* ProjectDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE433D8C6C908371422E9E3 /* ProjectDetailView.swift */; };
+		4F786E4007A7463FF1224BC4 /* WebSocketConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48E6F1382915379B3048B07A /* WebSocketConnectionManager.swift */; };
+		4FA7F667D0D7818078A279CD /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D338A67C42C34EA7A5F34CB9 /* NotificationSettingsView.swift */; };
+		50D6EE8F2DE87B5F96CA4FD5 /* MockVoiceOutputRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D0BF27553B9D15937606D9D /* MockVoiceOutputRepository.swift */; };
+		51E7A1C0B529AD821DBF4BDB /* RFNotificationBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0091DFD4063859F7357A52EF /* RFNotificationBanner.swift */; };
+		5202090B497489C821305526 /* ProgressMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D2E715CC7C6C779BB201966 /* ProgressMapper.swift */; };
+		5248F01C12D77D6B43AA7AA0 /* ObserveProgressUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC63BF2A36DEB6F8E414E00 /* ObserveProgressUseCaseTests.swift */; };
+		5293CB1747FECB9D94975F73 /* RFUploadProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F05B616E16FF794F92E424 /* RFUploadProgressView.swift */; };
+		52D1314E80B9B3827504E91E /* MockNotificationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E53636BACB18D634E302F01 /* MockNotificationRepository.swift */; };
+		53CA3BCB0C9149577DF1FB5E /* RFBiometricButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA90491980773FB61DE6751 /* RFBiometricButton.swift */; };
+		53CD1B6EF64AEBFFE77C7C91 /* RFImageMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3C516BC231E3C69265CF80 /* RFImageMessageView.swift */; };
+		53EE8B12B3AAA5FE2E8FF3E8 /* VoiceInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D3D03F824B5234DB2CE255 /* VoiceInputViewModel.swift */; };
+		55FFE6B80055DD880C80680D /* DeviceTokenDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91FB0E476FF189A678A9DC /* DeviceTokenDTO.swift */; };
+		5A603B913CF17307F80FEA25 /* FileUploadProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95DA37617833E9ED55D85BC /* FileUploadProgress.swift */; };
+		5AFB5D44BF96A2FCCB667BE5 /* SettingsRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB9277F8FB5FF307653B2DB /* SettingsRepositoryImpl.swift */; };
+		5B6F7CE82B6EBDD641DAB5B6 /* ApprovalTestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3D573C4FCB2B3CA5F38D93 /* ApprovalTestFactory.swift */; };
+		5D6D478EB4B39272CAC3207C /* WebSocketMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB4EC51AF46B7F748D4DDB1 /* WebSocketMessage.swift */; };
+		5ECD4C9BD68F9C09D20F5E20 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9EF868FB8B3129126B6185 /* HomeViewModel.swift */; };
+		5EF10B33094C6B775B55F8FF /* ProjectStatusRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726CA7D2B12A8012E6CEA268 /* ProjectStatusRepository.swift */; };
+		603B0EFE112BCD23843429BE /* GetProjectDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334E232A5C84D86BF0C4487A /* GetProjectDetailUseCase.swift */; };
+		6126E7278D2FF1AE83AA955E /* RFSpeechRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41ED0F098D2B09B8912AA1BF /* RFSpeechRecognizer.swift */; };
+		683999A7AAA0173449BEE8BF /* WebSocketMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E5613AC09F1BC3C47D904E /* WebSocketMessageTests.swift */; };
+		683E92792EA4E9C10756A27B /* AuthInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDDFA07B5EA521B249A6404 /* AuthInterceptorTests.swift */; };
+		68717A8857753A2E89F89966 /* WebSocketConnectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3867BA8F67E75819B7F8B40 /* WebSocketConnectionManagerTests.swift */; };
+		68E7170F1D4A0B0511B86304 /* RafRafTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77ECD792247535700E2AE98 /* RafRafTests.swift */; };
+		69BB92ECCA2D93A144EA055A /* NotificationRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89A7251A9986AF590322D9B1 /* NotificationRepositoryImpl.swift */; };
+		6B80EC328FFA12586B465DD0 /* ChatRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F653780F1553EA39EC97C85E /* ChatRepositoryProtocol.swift */; };
+		6C042BE5A215488A786F817B /* WebSocketClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F39AF4256F417AE5C96B4E /* WebSocketClientTests.swift */; };
+		6C436C809B7C4728E22079FC /* TTSMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D45E1077BE0DB5D8B8471A /* TTSMapper.swift */; };
+		6DE6DB6F070257976E7861F6 /* RFTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50CEA586C89F51C32CEF461 /* RFTextField.swift */; };
+		6E21CB6800808FF30162E496 /* AuthRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2AC6DDCE2301CABD2110DC /* AuthRepositoryImpl.swift */; };
+		6E57A7C79B809272E78BBBFA /* RFTypographyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D3E3C09D1313A1910F194C /* RFTypographyTests.swift */; };
+		6EB280CD6A954C9D2898A59E /* ProjectRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1E87C612CE695839F215FB /* ProjectRepositoryProtocol.swift */; };
+		6F623B970925898AF1BA733E /* ProjectListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50917FA7893DF99B7E119E32 /* ProjectListViewModel.swift */; };
+		6F9955265FD9FA3E2AFCDE08 /* MockProgressRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06F075CD564B7C9B302F557 /* MockProgressRepository.swift */; };
+		70138340EEEC83289A413EA2 /* DownloadFileUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E52C0850223ADA5F2594D99 /* DownloadFileUseCaseTests.swift */; };
+		70FBD109CFBA054CAD3A8FCF /* LoadChatHistoryUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EFE790132F623C0887C8BA5 /* LoadChatHistoryUseCase.swift */; };
+		713A4881DF334F581E84388C /* ApprovalOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319FC08A12062D681D3865ED /* ApprovalOption.swift */; };
+		71FF04CAA175B88FAE72AE79 /* VoiceInputState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE99A9CC802FA53865A170A8 /* VoiceInputState.swift */; };
+		720586133405485A2876C53F /* MockFileRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B19EC9D9485E170060FE3F /* MockFileRepository.swift */; };
+		720A276878F44B627F034860 /* VoiceOutputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B971BB8F0A8579AB206FAE7C /* VoiceOutputViewModel.swift */; };
+		7223739E25D8C0FF202B37BB /* GetProjectsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D35E8474601420710ED6CA8 /* GetProjectsUseCaseTests.swift */; };
+		72E118C7BE74A861C487790B /* ProgressMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2198BE7D92A94C10AAE85AD /* ProgressMapperTests.swift */; };
+		7421CD398BD04F2BDC04AA7E /* MockVoiceAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F745C0108B4145E7EF263 /* MockVoiceAudioPlayer.swift */; };
+		74DA8BF1ED8BBBAD6E720E0D /* FilePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084B22FA750C796D020FA70D /* FilePickerViewModel.swift */; };
+		74EBD4E5B6AC3883E755DFCA /* TranscriptionMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 245EE9BB70C1492C10B50AC4 /* TranscriptionMapperTests.swift */; };
+		7649EBAD8B21A59B66167260 /* RFVoiceInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C5EB5410DB1CD92C7780F4 /* RFVoiceInputView.swift */; };
+		76C10079D554065D4A3DB548 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884DCBB378AB332BCCE7C7E3 /* AuthManager.swift */; };
+		770A580D5151BCA0E6099978 /* RFFilePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546AAC0031A9F77C1AF58B6B /* RFFilePickerView.swift */; };
+		77DE5777F39B36D8A2BACD7D /* VoiceInputStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25274F3184E417CDB72FDE2A /* VoiceInputStateTests.swift */; };
+		78C20ABE8AC8A34BAF0F0952 /* ProjectListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C56E0953632D7176D2CE8C1 /* ProjectListView.swift */; };
+		79E0E4D5882597439861B862 /* TTSVoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFE526FB9C651EB7DCE792E /* TTSVoiceTests.swift */; };
+		7A9E864C63FA0554E738EFB3 /* ProgressRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41AA8948BA168061C1A7693 /* ProgressRepositoryImpl.swift */; };
+		7E1A8555C25F0D9364C2B9E9 /* VoiceInputRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92DE3CA5EDCE43142B45794 /* VoiceInputRepositoryProtocol.swift */; };
+		7F69C861FBECE104AB7AC76E /* WebSocketMessageRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0562ABFC489C98DF5B80B11F /* WebSocketMessageRouter.swift */; };
+		821F0574AAC95057BEE9DC1F /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910E048030BCE704D1ACC9F8 /* PushNotification.swift */; };
+		82775AD57DA8B1B053EBD608 /* RFText.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6016664D42539CA3682B2BB /* RFText.swift */; };
+		82DE6F3EE500AE3DFE1424FF /* ScreenshotViewerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51194784C4D4A291F0B8CEAE /* ScreenshotViewerState.swift */; };
+		82E1E1ED5AE6DD3A5BF0A669 /* MockSettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036FEC3776B23ACDD23096FA /* MockSettingsRepository.swift */; };
+		8323362B6FCD7F8A0594D05F /* RFVoiceInputButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D026E5183E0472546C7337C1 /* RFVoiceInputButton.swift */; };
+		84639ABFFAB351AF7B72C150 /* NotificationSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B7392B3C3929C15B48D2CD /* NotificationSettingsViewModel.swift */; };
+		85F48831C05227A4125ECE17 /* VoiceOutputRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA20ABC96037E772A9A2BE7 /* VoiceOutputRepositoryImpl.swift */; };
+		8631DD138898851D7B1EC5B1 /* RefreshTokenUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6B7BA7869125371EA75C10 /* RefreshTokenUseCase.swift */; };
+		8731A1F3065CA8D887333C03 /* RafRafApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E0B9813123EAFCAF6E5425 /* RafRafApp.swift */; };
+		898671F42572DA368D1C6997 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = E1E2A2A56BA5D07346F09E34 /* NukeUI */; };
+		8AB419F196184A4BC864ACB8 /* VoiceOutputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80169C157CC966EDF67F923F /* VoiceOutputViewModelTests.swift */; };
+		8ABCE16459E196294FBD136E /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C187324456AD9CD5097804E6 /* AuthInterceptor.swift */; };
+		8AFBF713036A6552D5EF92C3 /* FileTestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F9B3C372438247C548DEEC4 /* FileTestFactory.swift */; };
+		8C74F34C7922DDAA72AA59D9 /* FileDownloadResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E08A5F59D1C2E500A03406 /* FileDownloadResponseDTO.swift */; };
+		8E3780EE4B737661383464D4 /* RefreshTokenUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4BD449523E0B3C3C0E599A8 /* RefreshTokenUseCaseTests.swift */; };
+		90C2F03F9FEDE9C4BC4C172C /* SharedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873D341B8899DEFD0E0C6017 /* SharedFile.swift */; };
+		941B0A53882A36B1ED352971 /* ApprovalModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B034A26D2C78F515EE7DC5A /* ApprovalModelTests.swift */; };
+		948990E90BB339DCB927D712 /* AuthDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7257C2689A8E6A9F2385F6 /* AuthDTOs.swift */; };
+		951CC76E459C070DBE14DCD7 /* SynthesizeSpeechUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AD4E549ED602E49AA76507 /* SynthesizeSpeechUseCaseTests.swift */; };
+		96C1AE90CF7954ADE5C5BBC5 /* TTSRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96967D0E131F879DD93C6911 /* TTSRequest.swift */; };
+		97BF50FCDCBAC8DD8B199BDC /* RFFileAttachmentCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71E90843FD467D2984DD9E9 /* RFFileAttachmentCard.swift */; };
+		995ABFE19327680CECAD261A /* ScreenshotViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD0F371A5AE58F7716D94C5 /* ScreenshotViewerView.swift */; };
+		9965E3E5B82695EC0BE4E9CF /* LoadChatHistoryUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E989E4962D885164F6CACA /* LoadChatHistoryUseCaseTests.swift */; };
+		99FACAF4013440182B994660 /* BiometricAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E34C797F5A1B904C7BE6DE /* BiometricAuthManager.swift */; };
+		9C7F8E0EA6753D2F8D5E5CBC /* ProjectDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66AA94B64F205036F8707946 /* ProjectDetailViewModelTests.swift */; };
+		9C95BDEE6FE4779CB035A034 /* ProjectStatusMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4959793D375BCA1E8998696B /* ProjectStatusMapper.swift */; };
+		9CC04BC3F7D82C475AD74B15 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1ADDEFA8694886A954995E /* AppEnvironment.swift */; };
+		9DBD440AD8BA9DC30142CB52 /* FileMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA56FA16D9B33499BB1DB2B /* FileMapper.swift */; };
+		9E2FD1989B9E6AAA52B2FBA2 /* RFPlaybackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892254DE431505E6DF6AFEC3 /* RFPlaybackButton.swift */; };
+		9E438DF05967EBE422615DA5 /* RFScreenshotViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DF15DB7979A572992F5B /* RFScreenshotViewer.swift */; };
+		9E4F23134A68C9CC84A394B1 /* FileUploadResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C758CB8053C9CF929DA33B /* FileUploadResponseDTO.swift */; };
+		9EFF71224159A65F07F50A5F /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DCF48D283B68256FE6AD03 /* ChatMessage.swift */; };
+		9FCD8CB4BFE8F40FC4223322 /* RFLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747F8B6AF88D6C525824A2B4 /* RFLoadingView.swift */; };
+		A010C15DE98A70A25BCFAAE9 /* SupportedFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98519EB95B9F99313A9D3793 /* SupportedFileTypeTests.swift */; };
+		A21B88A6402FDD2B53F42D7F /* RFWaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FDCB895C361FB669FAEE86 /* RFWaveformView.swift */; };
+		A251112BB37D265712C60859 /* RFProjectStatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C39109AD4B14FB902DDDE1 /* RFProjectStatusBadge.swift */; };
+		A2ABE3A46A5D9EB3D516B95B /* MockChatRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C19344181D70DA7F175D9E /* MockChatRepository.swift */; };
+		A32481051F472709B19F6D75 /* RFCodeBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CD7C997F970FBA36D3C074 /* RFCodeBlock.swift */; };
+		A45276EAA22DCBACB3FB5896 /* AudioLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2DD0C74D5C60819C75A400 /* AudioLevelTests.swift */; };
+		A4E21319115E48A9BACD194E /* ChatRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BDBED213305ACA70334DBA /* ChatRepositoryImpl.swift */; };
+		A4E6BF9260001ED1544A8B72 /* NotificationMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 366FF9F51004CD680DDF3CB2 /* NotificationMapper.swift */; };
+		A540D1ACEA5D06D6C80C2F2A /* StopVoiceRecordingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37A177D1938F74CDAA6D30C /* StopVoiceRecordingUseCase.swift */; };
+		A597B8CEA836DFF91363EE02 /* VoiceInputTestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57A611E9759F629A8F4C5ED /* VoiceInputTestFactory.swift */; };
+		A5A655088C7FC6EE0F5AA9B8 /* FilePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3A1719F6E181EFA9D1B5DE /* FilePickerViewModelTests.swift */; };
+		A6E9039247DC4A73D17DD09E /* ChatMessageModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D8A55FE9AF917427DE9BBB /* ChatMessageModelTests.swift */; };
+		A8440D5A7E68DCC44E6EAFA9 /* MockApprovalRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDAA9F81B14E7D8A13DEC7E /* MockApprovalRepository.swift */; };
+		A89AC680DE7C152C2CD4F284 /* StartVoiceRecordingUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E81483960598B0E4BA4ECD /* StartVoiceRecordingUseCaseTests.swift */; };
+		A98693C70B9BBE3979DA0685 /* AppContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7907F9B240D2B0A7723AFE0 /* AppContainer.swift */; };
+		AA0C588BF79A91BBC6EC49D9 /* MockProjectRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9E456B2FE6369859C095F9 /* MockProjectRepository.swift */; };
+		ABE150397E1D4260350113E3 /* TranscriptionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D8160CA803E7D4E3A1214AF /* TranscriptionResult.swift */; };
+		ADBD7494FF02D52E57036464 /* ApprovalRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154B32F3E66E7DD27646B928 /* ApprovalRepositoryImpl.swift */; };
+		ADFE3CD8098A6AD2B1107FA4 /* ApprovalMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF2C47869AE1620A3BBEC2A /* ApprovalMapper.swift */; };
+		AE78026CAD68EE7743A9CF0B /* RFTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2839C39830CCECEE80290942 /* RFTypography.swift */; };
+		AECAC1C68D46FD67182E0DE8 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F752599A11956764AC8B10 /* AuthViewModel.swift */; };
+		B12D2683360A1BEE9F8C8B1B /* TTSRequestDTOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC24C8A34CD821C9003485F /* TTSRequestDTOTests.swift */; };
+		B196AAB927B6E4410EC2F59E /* FileUploadRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B7966D42658E0B614C3900 /* FileUploadRequestDTO.swift */; };
+		B534868086435D4FBA4D0090 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = 6E10A0D15B0B7D188A64F34E /* Nuke */; };
+		B58DB0C21072C716126D6BFF /* FileRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6B51A4354CBB85A0314750 /* FileRepositoryProtocol.swift */; };
+		B6CD7B8DDAFBD7F05F29B8C6 /* AuthMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554FB5635202438D8C671256 /* AuthMapperTests.swift */; };
+		B794433447C5FC8E6F3EF24A /* ChatAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5D1C4CC76AA7F60B425026 /* ChatAttachment.swift */; };
+		B7E953B959FAA27DA543C76D /* ProgressViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B726893F6FD86DF7513707C /* ProgressViewModelTests.swift */; };
+		B8EAE6E70D928471851D99E4 /* StopPlaybackUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2DD29420857C3A0B3A13879 /* StopPlaybackUseCase.swift */; };
+		B99E36C093DA02E389D6707F /* FileMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7CAEA24922BEBB6FB0C1BE /* FileMapperTests.swift */; };
+		BB804E5FCC4487FA6F17BBBE /* SubmitApprovalDecisionUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C25805409AC677AE951BA8 /* SubmitApprovalDecisionUseCaseTests.swift */; };
+		BB8F03022D41EA75F5C4B537 /* RFTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6A2CB9D986C62030FB1136 /* RFTextFieldTests.swift */; };
+		BD3EAE76FF7B0B49845C34EE /* NotificationPayloadDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F5D229C933E99E99E9C199 /* NotificationPayloadDTO.swift */; };
+		BEE32543ECCE5092CA35F951 /* LoadScreenshotUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194298D1B4B047D4196B5BC9 /* LoadScreenshotUseCase.swift */; };
+		BF1FDFE6A2A9D502C7B02365 /* RFCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F252D49D3EC1D709A56B1673 /* RFCard.swift */; };
+		BFD5AF56D7FC3C1C7D7A6DB8 /* VoiceOutputState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8C45FE6EB4CB9BC35B709B /* VoiceOutputState.swift */; };
+		C042AD76CA2A2AD4F64FDC4F /* UserProfileMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDC3315500C75ABF09F2FF1 /* UserProfileMapper.swift */; };
+		C04EECE10C7CB20D13384ACD /* ApprovalMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422F209F30ED7BFB450E98E0 /* ApprovalMapperTests.swift */; };
+		C0C58F1F61426CA96DCEFADE /* ProjectMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFB318AF6289ED14E926848 /* ProjectMapperTests.swift */; };
+		C104AC6C23ADF7BA097935AE /* VoiceInputRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472146B7B4BACE8CAD4276BA /* VoiceInputRepositoryImpl.swift */; };
+		C1925432A455B5B9A664E262 /* DeepgramMessageDTOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A233B6173D693D3E16616C /* DeepgramMessageDTOTests.swift */; };
+		C1CC0EB0386F7B80DF0AD0D1 /* NotificationRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249EF47971A35E816A840720 /* NotificationRouterTests.swift */; };
+		C8A5112302BF7D39C6D00224 /* RFVoiceOutputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4C539E69D7EF79983D17D97 /* RFVoiceOutputView.swift */; };
+		C8FEF24EC70EBFB3362DCDAF /* ChatMessageDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93E0C5E2CB85ADDF4C6157F /* ChatMessageDTO.swift */; };
+		C98FDB7766795513AEEB1A75 /* ProjectStatusMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD2FB07F7129641203B25A3 /* ProjectStatusMapperTests.swift */; };
+		CA7070818E078B512574EEC4 /* LogoutUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4770214A1452EB574E607F2 /* LogoutUseCase.swift */; };
+		CA89DBA76660BDE736B6CE49 /* ApprovalCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DD15C6A064EF730978BCC3 /* ApprovalCardViewModel.swift */; };
+		CAEC989FDB183AA2D7865152 /* TTSRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E22F1EE77DE2427DE1E085 /* TTSRequestTests.swift */; };
+		CC3D54FE8D12D799F04E419B /* ScreenshotMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0ACC5410D3BAB6F979A08BF /* ScreenshotMapper.swift */; };
+		CCABAE6C1D0350F09A27AE99 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED988AF5D675A2192F7CABF4 /* HomeViewModelTests.swift */; };
+		CDFBB3177E574C6A3174F774 /* VoiceOutputStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3198A348F640159070EE2331 /* VoiceOutputStateTests.swift */; };
+		CE6768C80CB433F3BBC46ED5 /* RFTypingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B34887B85ED882C16492C16 /* RFTypingIndicator.swift */; };
+		CEB59EDD52E3E003144110BE /* SaveSettingsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A961F116D1108B39252EE3C1 /* SaveSettingsUseCaseTests.swift */; };
+		CFDFBE7A7B06A275C7F9761C /* SupportedFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E9BF74CBB3574A290E0605 /* SupportedFileType.swift */; };
+		D1D8D7FD889AF9F9988C1B2D /* RFMessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F0C7A8C0EB877BF24E6FE1 /* RFMessageBubble.swift */; };
+		D20A4DF1D0A21ED665E7B805 /* SaveSettingsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C9096623185819E65CA1D7 /* SaveSettingsUseCase.swift */; };
+		D2378F47B5C1F00A35902C2F /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08BDCE9F985E5AFB0A26ABCB /* HomeView.swift */; };
+		D2EE4339B1BF3012C62EB2E4 /* NotificationCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91B37544AF71EF06D1F7BC4 /* NotificationCategory.swift */; };
+		D301FE4FCFA755A12544C3B7 /* FileRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A681B9DE77FED4F72FFE999 /* FileRepositoryImpl.swift */; };
+		D3587F0CD1FAE5126EE9387F /* ProjectRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E745D17E31094BA30A4732FD /* ProjectRepositoryImpl.swift */; };
+		D603913E1499B617128063BC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4813BF26B2B15D0D2CA06EB /* AppDelegate.swift */; };
+		D67D1D8C54D4B04159DA28FE /* TTSVoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E3A66FF0F6E229066CE9A9 /* TTSVoice.swift */; };
+		D730FC59FDFAC53D8CB78C9F /* SettingsRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFC704C8E7E3FCFAA61D0D8 /* SettingsRepositoryProtocol.swift */; };
+		DA979C1B30AEA06D8EC2C330 /* ProgressStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C9C9B4827904B306AD71B5 /* ProgressStep.swift */; };
+		DAF965C1CCB995AD0E832DA5 /* SettingsTestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FFD418418E0FE4B18EFF0A /* SettingsTestFactory.swift */; };
+		DCB3FF8BA26864D706D72195 /* MockScreenshotRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82705500948A44192CC29295 /* MockScreenshotRepository.swift */; };
+		DFA161097F54448F3606E4F4 /* ChatMessageMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DFD891B89F50F8D52363BE /* ChatMessageMapperTests.swift */; };
+		DFAA7555B73340B4FEE64E1A /* RFPlaybackProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD54C402190CF29D5AADD728 /* RFPlaybackProgressBar.swift */; };
+		E033ECD6FDB5F442243A5D54 /* HandleNotificationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E40E45FC70F75C1A03072E /* HandleNotificationUseCaseTests.swift */; };
+		E03DDF57418D07DA468DE23C /* WebSocketMessageRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1212FBA12B30AFF5733A8267 /* WebSocketMessageRouterTests.swift */; };
+		E2C742F6DA327081E0D2B7A9 /* ProgressRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D92C29137D78716255B365 /* ProgressRepositoryProtocol.swift */; };
+		E33D453E15C9E01E59278C0F /* VoiceLanguageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957F7F221FCC3D03CD9A40FD /* VoiceLanguageTests.swift */; };
+		E37154C32EDE14FFC8288D16 /* RFLanguageSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D101B741ABFC1B7514DADBFE /* RFLanguageSelector.swift */; };
+		E38F6D750F0992BD53A0C01C /* VoiceLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD43B55D9F303CA181C0D313 /* VoiceLanguage.swift */; };
+		E40BE71EC32FC867F700DC7D /* AuthViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F742FCF558A34BDC0E65CC3 /* AuthViewModelTests.swift */; };
+		E4B632FB67D23B0519699CB1 /* RFSpeedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0624F3BB62C9C6181240329F /* RFSpeedControl.swift */; };
+		E4D20264B06E3BA886B7BE9D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F64086A1002320F2E9FF4D3 /* ContentView.swift */; };
+		E5ED3D543074B50FD6ED7263 /* LoadSettingsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAC60F0C5E533BCE8BA4A67A /* LoadSettingsUseCase.swift */; };
+		E6E3A88D075CF310736237A0 /* UploadFileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A65E5F15056A62DCEC6C111 /* UploadFileUseCase.swift */; };
+		E7574480EB35E3895E822873 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8335D87CD04F6914A8C6A8D1 /* SettingsView.swift */; };
+		E9D28408EC9CAA36465ACCDE /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2651903EEF68D395535F775 /* SettingsViewModelTests.swift */; };
+		EAC285BFE9399C9A34318A47 /* ScreenshotRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7349869B86F354624F54074F /* ScreenshotRepositoryImpl.swift */; };
+		EC27E0DDC9D27BB3247B76AF /* AuthRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379099FF7A346C1A45E43D0A /* AuthRepository.swift */; };
+		ECC7B3DF4ECCF0C169F926C2 /* BiometricAuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296C5F89DB28B601903F738E /* BiometricAuthManagerTests.swift */; };
+		ECEAC4C72130EC02BAF267E9 /* VoiceOutputRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599BD9251B142BAAB1AB3243 /* VoiceOutputRepositoryProtocol.swift */; };
+		EDFAA96C8F5C83B957E1DC86 /* RFColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECFBBAEFFE940FB82263775 /* RFColors.swift */; };
+		EECAA7A546A3DD77278EDB3F /* SubmitApprovalDecisionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA61012D78580A68D7F7FD5 /* SubmitApprovalDecisionUseCase.swift */; };
+		EF5E63D4A4015423C2C4BA2F /* UserProfileDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71B262091F1518F1D4513B24 /* UserProfileDTO.swift */; };
+		EFCD551C0C3025172F7FBA61 /* RFProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC28F395365755DC07DC227A /* RFProgressIndicator.swift */; };
+		F01B19A772173B4171C6F451 /* RFRegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C674551BDF23B45BDDEEA1 /* RFRegisterView.swift */; };
+		F02FDF797BF94067EDB7FD69 /* TTSAudioCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517B68594F651F57917C24EE /* TTSAudioCache.swift */; };
+		F116E333753F605825908560 /* LoadSettingsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C0B926BBA0C8F6EBBAA19C /* LoadSettingsUseCaseTests.swift */; };
+		F25459C2C9FA9461DB5DB51D /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2414963E26EADDBD66E7BCF7 /* AuthManagerTests.swift */; };
+		F29DEC7E12B40AE5E40A9260 /* AuthMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3E05119E588957102E442F /* AuthMapper.swift */; };
+		F2C1C0B1F7E28C6CA820E9BC /* RFButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525558CAE23C387B75FB9154 /* RFButtonTests.swift */; };
+		F451E7C0EC330B8B9B9069B1 /* View+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6124D6E1DECAB58D50AE8B0 /* View+Extensions.swift */; };
+		F66535758ABA5F61656881A0 /* ProjectListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 180F43D46C4EF6B37661F039 /* ProjectListViewModelTests.swift */; };
+		F6714D7D1A45086156152B93 /* SendMessageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53122A6023B9C8527386D149 /* SendMessageUseCase.swift */; };
+		F96D453993430F1AE425A673 /* RegisterDeviceTokenUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC11AC16AFB4F0AE3B6291D /* RegisterDeviceTokenUseCaseTests.swift */; };
+		FA5EA21A153E4070D5EC0479 /* ProgressRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108EEC88530B42D3365B0CF7 /* ProgressRepositoryImplTests.swift */; };
+		FAEEF0302FBB337424A8235A /* TranscriptionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6806D0CBEB4C320AB5122A0A /* TranscriptionMapper.swift */; };
+		FB1623A4889699FE2BCB3C4C /* ChatViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03CACBAE25C8A38ECF7B45C /* ChatViewModelTests.swift */; };
+		FC196297F8982111BF52B197 /* LoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED8584735CB9CC73F0A3192 /* LoginUseCase.swift */; };
+		FC69316AA142DF6D1E44265B /* TTSMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F36517B94A8021E276737B /* TTSMapperTests.swift */; };
+		FC7306E255FD9A39D77FFB07 /* ProjectMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895687B790F7F39124904D09 /* ProjectMapper.swift */; };
+		FC870F57F8296F7A057C2D65 /* StartVoiceRecordingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100910A3D82B228DF6E889C /* StartVoiceRecordingUseCase.swift */; };
+		FDD1A5FB33590ABD19B5939C /* RFScreenshotFullScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C9DD548ED813FFD84304A3 /* RFScreenshotFullScreenView.swift */; };
+		FE20ACD5165C00FA5E05D89D /* LoadScreenshotUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81462513B22C5B10107DE1C8 /* LoadScreenshotUseCaseTests.swift */; };
+		FE9DD255E14A8684F283232B /* Factory in Frameworks */ = {isa = PBXBuildFile; productRef = ECB3212567B4D6E2AE1748D8 /* Factory */; };
+		FF2F90675AC4434D50B7CC14 /* ProgressEventDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9999729875223B6921FC95AB /* ProgressEventDTO.swift */; };
+		FFF07533B53FC9F056179983 /* NotificationCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384E4B954363B2EE0FDCDB7C /* NotificationCategoryTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		F610CCABE0070928371DC439 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 07E1E16FD89DE3C0B3FD36FA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2CC52146BD6CF99A70B8CFA3;
+			remoteInfo = RafRaf;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0091DFD4063859F7357A52EF /* RFNotificationBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFNotificationBanner.swift; sourceTree = "<group>"; };
+		00C758CB8053C9CF929DA33B /* FileUploadResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadResponseDTO.swift; sourceTree = "<group>"; };
+		012C760BCD578912C69FF278 /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
+		0311D62510D1BCEA61F04553 /* KeychainHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelperTests.swift; sourceTree = "<group>"; };
+		036FEC3776B23ACDD23096FA /* MockSettingsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSettingsRepository.swift; sourceTree = "<group>"; };
+		03A5DF15DB7979A572992F5B /* RFScreenshotViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFScreenshotViewer.swift; sourceTree = "<group>"; };
+		03AD4E549ED602E49AA76507 /* SynthesizeSpeechUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynthesizeSpeechUseCaseTests.swift; sourceTree = "<group>"; };
+		03BAA8A08BABA9E6CCBB3CC5 /* RFVoiceSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFVoiceSelector.swift; sourceTree = "<group>"; };
+		0562ABFC489C98DF5B80B11F /* WebSocketMessageRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketMessageRouter.swift; sourceTree = "<group>"; };
+		0617A5997B3B90CE3D2AE134 /* RFChatInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFChatInput.swift; sourceTree = "<group>"; };
+		0624F3BB62C9C6181240329F /* RFSpeedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFSpeedControl.swift; sourceTree = "<group>"; };
+		07256F747ADB59F141BD6018 /* TTSAudioResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSAudioResult.swift; sourceTree = "<group>"; };
+		073B5D01B9C1C155E7F5A50C /* NotificationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRouter.swift; sourceTree = "<group>"; };
+		084B22FA750C796D020FA70D /* FilePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePickerViewModel.swift; sourceTree = "<group>"; };
+		08BDCE9F985E5AFB0A26ABCB /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		08F03CE4C7201D9AFD3FA1D1 /* ScreenshotViewerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotViewerViewModelTests.swift; sourceTree = "<group>"; };
+		09D92C29137D78716255B365 /* ProgressRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressRepositoryProtocol.swift; sourceTree = "<group>"; };
+		0BA37EB0CDF96E19A3DECC86 /* MockVoiceInputRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockVoiceInputRepository.swift; sourceTree = "<group>"; };
+		0D27E77CD6F518CFAFDCBEF2 /* RFApprovalOptionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFApprovalOptionButton.swift; sourceTree = "<group>"; };
+		0D35E8474601420710ED6CA8 /* GetProjectsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProjectsUseCaseTests.swift; sourceTree = "<group>"; };
+		0DA1AB7899F9DFDFABB9E7A4 /* DeepgramMessageDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepgramMessageDTO.swift; sourceTree = "<group>"; };
+		0DD4187290AB38FC00C47889 /* ScreenshotDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotDTO.swift; sourceTree = "<group>"; };
+		0ECFBBAEFFE940FB82263775 /* RFColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFColors.swift; sourceTree = "<group>"; };
+		0F9B3C372438247C548DEEC4 /* FileTestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTestFactory.swift; sourceTree = "<group>"; };
+		0FADD172BD04821AA0F68F16 /* GetProjectsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProjectsUseCase.swift; sourceTree = "<group>"; };
+		108EEC88530B42D3365B0CF7 /* ProgressRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressRepositoryImplTests.swift; sourceTree = "<group>"; };
+		1212FBA12B30AFF5733A8267 /* WebSocketMessageRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketMessageRouterTests.swift; sourceTree = "<group>"; };
+		154B32F3E66E7DD27646B928 /* ApprovalRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalRepositoryImpl.swift; sourceTree = "<group>"; };
+		1776AD17EDD35DB4E0121C58 /* TTSAudioResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSAudioResultTests.swift; sourceTree = "<group>"; };
+		17C0B926BBA0C8F6EBBAA19C /* LoadSettingsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadSettingsUseCaseTests.swift; sourceTree = "<group>"; };
+		180F43D46C4EF6B37661F039 /* ProjectListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectListViewModelTests.swift; sourceTree = "<group>"; };
+		187375870FE1385F61CC29DA /* NotificationMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationMapperTests.swift; sourceTree = "<group>"; };
+		18F6A7FF298FF847CDAE8333 /* BiometricLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricLoginUseCase.swift; sourceTree = "<group>"; };
+		194298D1B4B047D4196B5BC9 /* LoadScreenshotUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadScreenshotUseCase.swift; sourceTree = "<group>"; };
+		1B5D1C4CC76AA7F60B425026 /* ChatAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachment.swift; sourceTree = "<group>"; };
+		1C365DE11989085900D374D8 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
+		1C56E0953632D7176D2CE8C1 /* ProjectListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectListView.swift; sourceTree = "<group>"; };
+		1F9EF868FB8B3129126B6185 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		207A34477514118FB3C20E6C /* ScreenshotModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotModelTests.swift; sourceTree = "<group>"; };
+		20CD7C997F970FBA36D3C074 /* RFCodeBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFCodeBlock.swift; sourceTree = "<group>"; };
+		2100910A3D82B228DF6E889C /* StartVoiceRecordingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartVoiceRecordingUseCase.swift; sourceTree = "<group>"; };
+		215C7199300B4BE5F1DB5D5A /* ScreenshotRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotRepositoryProtocol.swift; sourceTree = "<group>"; };
+		21C674551BDF23B45BDDEEA1 /* RFRegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFRegisterView.swift; sourceTree = "<group>"; };
+		21F39AF4256F417AE5C96B4E /* WebSocketClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClientTests.swift; sourceTree = "<group>"; };
+		2414963E26EADDBD66E7BCF7 /* AuthManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManagerTests.swift; sourceTree = "<group>"; };
+		245EE9BB70C1492C10B50AC4 /* TranscriptionMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionMapperTests.swift; sourceTree = "<group>"; };
+		249EF47971A35E816A840720 /* NotificationRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRouterTests.swift; sourceTree = "<group>"; };
+		25274F3184E417CDB72FDE2A /* VoiceInputStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputStateTests.swift; sourceTree = "<group>"; };
+		26E40E45FC70F75C1A03072E /* HandleNotificationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleNotificationUseCaseTests.swift; sourceTree = "<group>"; };
+		2839C39830CCECEE80290942 /* RFTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFTypography.swift; sourceTree = "<group>"; };
+		296C5F89DB28B601903F738E /* BiometricAuthManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricAuthManagerTests.swift; sourceTree = "<group>"; };
+		29C9C9B4827904B306AD71B5 /* ProgressStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressStep.swift; sourceTree = "<group>"; };
+		29D3E3C09D1313A1910F194C /* RFTypographyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFTypographyTests.swift; sourceTree = "<group>"; };
+		2AD7EB1A7F663F2AE599276F /* ScreenshotDTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotDTOTests.swift; sourceTree = "<group>"; };
+		2B3A1719F6E181EFA9D1B5DE /* FilePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePickerViewModelTests.swift; sourceTree = "<group>"; };
+		2B6378F006F2E44C0E575BBC /* RFButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFButton.swift; sourceTree = "<group>"; };
+		2BB47CD519D01037848C453D /* Screenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screenshot.swift; sourceTree = "<group>"; };
+		2C7257C2689A8E6A9F2385F6 /* AuthDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDTOs.swift; sourceTree = "<group>"; };
+		2DDAA4E5F9C097B9A0DCD3ED /* RFFilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFFilePreviewView.swift; sourceTree = "<group>"; };
+		2E90391D47DE86AFCDF0FE1D /* RFCountdownTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFCountdownTimer.swift; sourceTree = "<group>"; };
+		2F3EBF23EE03D49A6FCB28F2 /* ProgressTestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressTestFactory.swift; sourceTree = "<group>"; };
+		3198A348F640159070EE2331 /* VoiceOutputStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOutputStateTests.swift; sourceTree = "<group>"; };
+		319FC08A12062D681D3865ED /* ApprovalOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalOption.swift; sourceTree = "<group>"; };
+		31DD15C6A064EF730978BCC3 /* ApprovalCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalCardViewModel.swift; sourceTree = "<group>"; };
+		32C50619DD04EF18D55CB97E /* RFSpacingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFSpacingTests.swift; sourceTree = "<group>"; };
+		334E232A5C84D86BF0C4487A /* GetProjectDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProjectDetailUseCase.swift; sourceTree = "<group>"; };
+		363B74F897CDBED36B83D849 /* ProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressView.swift; sourceTree = "<group>"; };
+		366FF9F51004CD680DDF3CB2 /* NotificationMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationMapper.swift; sourceTree = "<group>"; };
+		371ADE781BE1D773A3E1CD89 /* RFLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFLoginView.swift; sourceTree = "<group>"; };
+		379099FF7A346C1A45E43D0A /* AuthRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRepository.swift; sourceTree = "<group>"; };
+		37FFD418418E0FE4B18EFF0A /* SettingsTestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTestFactory.swift; sourceTree = "<group>"; };
+		384E4B954363B2EE0FDCDB7C /* NotificationCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCategoryTests.swift; sourceTree = "<group>"; };
+		38D3D086D405CEE09599451F /* RFToolStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFToolStatusView.swift; sourceTree = "<group>"; };
+		39B7392B3C3929C15B48D2CD /* NotificationSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsViewModel.swift; sourceTree = "<group>"; };
+		3B1ADDEFA8694886A954995E /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
+		3B34887B85ED882C16492C16 /* RFTypingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFTypingIndicator.swift; sourceTree = "<group>"; };
+		3B841E5C35A563010F7F8A41 /* SettingsRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRepositoryImplTests.swift; sourceTree = "<group>"; };
+		3D9E456B2FE6369859C095F9 /* MockProjectRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProjectRepository.swift; sourceTree = "<group>"; };
+		3DFC704C8E7E3FCFAA61D0D8 /* SettingsRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRepositoryProtocol.swift; sourceTree = "<group>"; };
+		3E53636BACB18D634E302F01 /* MockNotificationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNotificationRepository.swift; sourceTree = "<group>"; };
+		3EFD5ABF35F2A79B997B8A09 /* RFApprovalCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFApprovalCard.swift; sourceTree = "<group>"; };
+		41ED0F098D2B09B8912AA1BF /* RFSpeechRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFSpeechRecognizer.swift; sourceTree = "<group>"; };
+		422F209F30ED7BFB450E98E0 /* ApprovalMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalMapperTests.swift; sourceTree = "<group>"; };
+		429F7CAB9685E8ABE03DB4E0 /* RafRafTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = RafRafTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		45410A8C9586B7AC9E5F0343 /* ProjectDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectDTO.swift; sourceTree = "<group>"; };
+		45E08A5F59D1C2E500A03406 /* FileDownloadResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloadResponseDTO.swift; sourceTree = "<group>"; };
+		46D8A55FE9AF917427DE9BBB /* ChatMessageModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageModelTests.swift; sourceTree = "<group>"; };
+		472146B7B4BACE8CAD4276BA /* VoiceInputRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputRepositoryImpl.swift; sourceTree = "<group>"; };
+		48E6F1382915379B3048B07A /* WebSocketConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketConnectionManager.swift; sourceTree = "<group>"; };
+		4959793D375BCA1E8998696B /* ProjectStatusMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectStatusMapper.swift; sourceTree = "<group>"; };
+		4BD2FB07F7129641203B25A3 /* ProjectStatusMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectStatusMapperTests.swift; sourceTree = "<group>"; };
+		4BFD733653E0525C72ACFCB1 /* FileMetadataDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMetadataDTO.swift; sourceTree = "<group>"; };
+		4D8160CA803E7D4E3A1214AF /* TranscriptionResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionResult.swift; sourceTree = "<group>"; };
+		4DDE9A2B7D05F73EA7526AA7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		4EB9277F8FB5FF307653B2DB /* SettingsRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRepositoryImpl.swift; sourceTree = "<group>"; };
+		4F64086A1002320F2E9FF4D3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		50917FA7893DF99B7E119E32 /* ProjectListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectListViewModel.swift; sourceTree = "<group>"; };
+		51194784C4D4A291F0B8CEAE /* ScreenshotViewerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotViewerState.swift; sourceTree = "<group>"; };
+		517B68594F651F57917C24EE /* TTSAudioCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSAudioCache.swift; sourceTree = "<group>"; };
+		525558CAE23C387B75FB9154 /* RFButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFButtonTests.swift; sourceTree = "<group>"; };
+		53122A6023B9C8527386D149 /* SendMessageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendMessageUseCase.swift; sourceTree = "<group>"; };
+		546AAC0031A9F77C1AF58B6B /* RFFilePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFFilePickerView.swift; sourceTree = "<group>"; };
+		554FB5635202438D8C671256 /* AuthMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthMapperTests.swift; sourceTree = "<group>"; };
+		58B5C79F81BBBAB0FC37BF61 /* RFSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFSpacing.swift; sourceTree = "<group>"; };
+		58E9BF74CBB3574A290E0605 /* SupportedFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedFileType.swift; sourceTree = "<group>"; };
+		5992E0A0F127905160F54939 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
+		599BD9251B142BAAB1AB3243 /* VoiceOutputRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOutputRepositoryProtocol.swift; sourceTree = "<group>"; };
+		5A65E5F15056A62DCEC6C111 /* UploadFileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadFileUseCase.swift; sourceTree = "<group>"; };
+		5C1E87C612CE695839F215FB /* ProjectRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectRepositoryProtocol.swift; sourceTree = "<group>"; };
+		5CC24C8A34CD821C9003485F /* TTSRequestDTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSRequestDTOTests.swift; sourceTree = "<group>"; };
+		5D34BFB48FE8E9FCA8D65AA6 /* TTSRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSRequestDTO.swift; sourceTree = "<group>"; };
+		5E2DD85745706E339B58077A /* NotificationRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRepositoryProtocol.swift; sourceTree = "<group>"; };
+		5E52C0850223ADA5F2594D99 /* DownloadFileUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFileUseCaseTests.swift; sourceTree = "<group>"; };
+		5FA90491980773FB61DE6751 /* RFBiometricButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFBiometricButton.swift; sourceTree = "<group>"; };
+		629C0C741A2EA1DCC248E89B /* RFSettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFSettingsRow.swift; sourceTree = "<group>"; };
+		63C25805409AC677AE951BA8 /* SubmitApprovalDecisionUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitApprovalDecisionUseCaseTests.swift; sourceTree = "<group>"; };
+		65A7CF6BE6C6D35BDCF28F53 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
+		66AA94B64F205036F8707946 /* ProjectDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectDetailViewModelTests.swift; sourceTree = "<group>"; };
+		66E9B6A86D86A85928EC43D4 /* RegisterDeviceTokenUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterDeviceTokenUseCase.swift; sourceTree = "<group>"; };
+		6806D0CBEB4C320AB5122A0A /* TranscriptionMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionMapper.swift; sourceTree = "<group>"; };
+		68EDD58FB04BAB8CFFBF18E2 /* ScreenshotTestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTestFactory.swift; sourceTree = "<group>"; };
+		6B034A26D2C78F515EE7DC5A /* ApprovalModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalModelTests.swift; sourceTree = "<group>"; };
+		6B2D1ED44EF7C4C281C1C692 /* ScreenshotMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotMapperTests.swift; sourceTree = "<group>"; };
+		6BA56FA16D9B33499BB1DB2B /* FileMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMapper.swift; sourceTree = "<group>"; };
+		6D0BF27553B9D15937606D9D /* MockVoiceOutputRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockVoiceOutputRepository.swift; sourceTree = "<group>"; };
+		6D2E715CC7C6C779BB201966 /* ProgressMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressMapper.swift; sourceTree = "<group>"; };
+		6E5B2EDFD388B80900006C19 /* ApprovalQuestionDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalQuestionDTO.swift; sourceTree = "<group>"; };
+		6EA20ABC96037E772A9A2BE7 /* VoiceOutputRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOutputRepositoryImpl.swift; sourceTree = "<group>"; };
+		71B262091F1518F1D4513B24 /* UserProfileDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileDTO.swift; sourceTree = "<group>"; };
+		71C93280E1D8CE2C3ED37AB6 /* PushNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManager.swift; sourceTree = "<group>"; };
+		726CA7D2B12A8012E6CEA268 /* ProjectStatusRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectStatusRepository.swift; sourceTree = "<group>"; };
+		7349869B86F354624F54074F /* ScreenshotRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotRepositoryImpl.swift; sourceTree = "<group>"; };
+		73EDDECB3A8862452651E8E2 /* RFErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFErrorView.swift; sourceTree = "<group>"; };
+		747F8B6AF88D6C525824A2B4 /* RFLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFLoadingView.swift; sourceTree = "<group>"; };
+		79C9096623185819E65CA1D7 /* SaveSettingsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveSettingsUseCase.swift; sourceTree = "<group>"; };
+		7CCE0E6590187D6D085DD904 /* ApprovalQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalQuestion.swift; sourceTree = "<group>"; };
+		7F742FCF558A34BDC0E65CC3 /* AuthViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModelTests.swift; sourceTree = "<group>"; };
+		80169C157CC966EDF67F923F /* VoiceOutputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOutputViewModelTests.swift; sourceTree = "<group>"; };
+		81462513B22C5B10107DE1C8 /* LoadScreenshotUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadScreenshotUseCaseTests.swift; sourceTree = "<group>"; };
+		822D1B3519782E19AAE6B807 /* RFAvatar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFAvatar.swift; sourceTree = "<group>"; };
+		82705500948A44192CC29295 /* MockScreenshotRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockScreenshotRepository.swift; sourceTree = "<group>"; };
+		82E989E4962D885164F6CACA /* LoadChatHistoryUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadChatHistoryUseCaseTests.swift; sourceTree = "<group>"; };
+		8335D87CD04F6914A8C6A8D1 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		839DFFD5CDFE6D3EA5CC1B8A /* RFAudioSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFAudioSessionManager.swift; sourceTree = "<group>"; };
+		844C2FAAA839BD62A7A4E1F4 /* ObserveProgressUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserveProgressUseCase.swift; sourceTree = "<group>"; };
+		873A95A473C0B0BC9B36ACED /* RFCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFCardTests.swift; sourceTree = "<group>"; };
+		873D341B8899DEFD0E0C6017 /* SharedFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedFile.swift; sourceTree = "<group>"; };
+		87C5EB5410DB1CD92C7780F4 /* RFVoiceInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFVoiceInputView.swift; sourceTree = "<group>"; };
+		88476BCA795924931C66A42B /* ApprovalQuestionDTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalQuestionDTOTests.swift; sourceTree = "<group>"; };
+		884DCBB378AB332BCCE7C7E3 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
+		88F05B616E16FF794F92E424 /* RFUploadProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFUploadProgressView.swift; sourceTree = "<group>"; };
+		892254DE431505E6DF6AFEC3 /* RFPlaybackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFPlaybackButton.swift; sourceTree = "<group>"; };
+		895687B790F7F39124904D09 /* ProjectMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMapper.swift; sourceTree = "<group>"; };
+		89A7251A9986AF590322D9B1 /* NotificationRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRepositoryImpl.swift; sourceTree = "<group>"; };
+		89E22F1EE77DE2427DE1E085 /* TTSRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSRequestTests.swift; sourceTree = "<group>"; };
+		8A066A9189723C78D76BD8E1 /* ScreenshotViewerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotViewerViewModel.swift; sourceTree = "<group>"; };
+		8B726893F6FD86DF7513707C /* ProgressViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewModelTests.swift; sourceTree = "<group>"; };
+		8CA61012D78580A68D7F7FD5 /* SubmitApprovalDecisionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitApprovalDecisionUseCase.swift; sourceTree = "<group>"; };
+		910E048030BCE704D1ACC9F8 /* PushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotification.swift; sourceTree = "<group>"; };
+		91541D471DBA109AA6FADD7B /* RafRaf.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = RafRaf.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		918A3F002FFBE2BE8D9EB4F5 /* UserRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepositoryProtocol.swift; sourceTree = "<group>"; };
+		919770F140B17FDB577BAC91 /* AppSettingsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsModelTests.swift; sourceTree = "<group>"; };
+		92E34C797F5A1B904C7BE6DE /* BiometricAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricAuthManager.swift; sourceTree = "<group>"; };
+		93269E459ED3188CC38BD6A0 /* SendMessageUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendMessageUseCaseTests.swift; sourceTree = "<group>"; };
+		9425CF331038E45CABFF6BFE /* VoiceOutputTestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOutputTestFactory.swift; sourceTree = "<group>"; };
+		9451177087744E75E0DBE274 /* VoiceAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioPlayer.swift; sourceTree = "<group>"; };
+		957F7F221FCC3D03CD9A40FD /* VoiceLanguageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceLanguageTests.swift; sourceTree = "<group>"; };
+		95B7966D42658E0B614C3900 /* FileUploadRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadRequestDTO.swift; sourceTree = "<group>"; };
+		96967D0E131F879DD93C6911 /* TTSRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSRequest.swift; sourceTree = "<group>"; };
+		975ABDD02BBE17015B5B12B8 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
+		98519EB95B9F99313A9D3793 /* SupportedFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedFileTypeTests.swift; sourceTree = "<group>"; };
+		9999729875223B6921FC95AB /* ProgressEventDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressEventDTO.swift; sourceTree = "<group>"; };
+		9A681B9DE77FED4F72FFE999 /* FileRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileRepositoryImpl.swift; sourceTree = "<group>"; };
+		9B14A5823261777D9A44ECCE /* RFEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFEmptyStateView.swift; sourceTree = "<group>"; };
+		9B3C516BC231E3C69265CF80 /* RFImageMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFImageMessageView.swift; sourceTree = "<group>"; };
+		9B4F745C0108B4145E7EF263 /* MockVoiceAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockVoiceAudioPlayer.swift; sourceTree = "<group>"; };
+		9B6B7BA7869125371EA75C10 /* RefreshTokenUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshTokenUseCase.swift; sourceTree = "<group>"; };
+		9D1BED62AE03EC1F750E0D07 /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
+		9DD0F371A5AE58F7716D94C5 /* ScreenshotViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotViewerView.swift; sourceTree = "<group>"; };
+		9DDDFA07B5EA521B249A6404 /* AuthInterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptorTests.swift; sourceTree = "<group>"; };
+		9EFE790132F623C0887C8BA5 /* LoadChatHistoryUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadChatHistoryUseCase.swift; sourceTree = "<group>"; };
+		9FA104FEB0FD2EFD04B0CD61 /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
+		9FC63BF2A36DEB6F8E414E00 /* ObserveProgressUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserveProgressUseCaseTests.swift; sourceTree = "<group>"; };
+		A2651903EEF68D395535F775 /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
+		A28FA43D580A4C8DCD750BFD /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
+		A3867BA8F67E75819B7F8B40 /* WebSocketConnectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketConnectionManagerTests.swift; sourceTree = "<group>"; };
+		A60848B934A2BFAEBE6FBD0F /* RFProjectCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFProjectCard.swift; sourceTree = "<group>"; };
+		A8BC517FE8F386693CAEE3FF /* ProgressState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressState.swift; sourceTree = "<group>"; };
+		A95DA37617833E9ED55D85BC /* FileUploadProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadProgress.swift; sourceTree = "<group>"; };
+		A961F116D1108B39252EE3C1 /* SaveSettingsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveSettingsUseCaseTests.swift; sourceTree = "<group>"; };
+		AD54C402190CF29D5AADD728 /* RFPlaybackProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFPlaybackProgressBar.swift; sourceTree = "<group>"; };
+		AD6B51A4354CBB85A0314750 /* FileRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileRepositoryProtocol.swift; sourceTree = "<group>"; };
+		B00D12AD59FE69B29E947D16 /* MockAuthRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthRepository.swift; sourceTree = "<group>"; };
+		B0F0C7A8C0EB877BF24E6FE1 /* RFMessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFMessageBubble.swift; sourceTree = "<group>"; };
+		B3D45E1077BE0DB5D8B8471A /* TTSMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSMapper.swift; sourceTree = "<group>"; };
+		B3DCF48D283B68256FE6AD03 /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
+		B4770214A1452EB574E607F2 /* LogoutUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutUseCase.swift; sourceTree = "<group>"; };
+		B4BD449523E0B3C3C0E599A8 /* RefreshTokenUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshTokenUseCaseTests.swift; sourceTree = "<group>"; };
+		B5F5D229C933E99E99E9C199 /* NotificationPayloadDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPayloadDTO.swift; sourceTree = "<group>"; };
+		B71E90843FD467D2984DD9E9 /* RFFileAttachmentCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFFileAttachmentCard.swift; sourceTree = "<group>"; };
+		B77ECD792247535700E2AE98 /* RafRafTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RafRafTests.swift; sourceTree = "<group>"; };
+		B7BDBED213305ACA70334DBA /* ChatRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRepositoryImpl.swift; sourceTree = "<group>"; };
+		B971BB8F0A8579AB206FAE7C /* VoiceOutputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOutputViewModel.swift; sourceTree = "<group>"; };
+		BAC11AC16AFB4F0AE3B6291D /* RegisterDeviceTokenUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterDeviceTokenUseCaseTests.swift; sourceTree = "<group>"; };
+		BC28F395365755DC07DC227A /* RFProgressIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFProgressIndicator.swift; sourceTree = "<group>"; };
+		BCFB318AF6289ED14E926848 /* ProjectMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMapperTests.swift; sourceTree = "<group>"; };
+		BF7CAEA24922BEBB6FB0C1BE /* FileMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMapperTests.swift; sourceTree = "<group>"; };
+		BFAFAD24416A098AFFD9D60C /* AuthModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthModels.swift; sourceTree = "<group>"; };
+		BFDAA9F81B14E7D8A13DEC7E /* MockApprovalRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockApprovalRepository.swift; sourceTree = "<group>"; };
+		C0ACC5410D3BAB6F979A08BF /* ScreenshotMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotMapper.swift; sourceTree = "<group>"; };
+		C14699F016E8A261A536C426 /* SynthesizeSpeechUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynthesizeSpeechUseCase.swift; sourceTree = "<group>"; };
+		C187324456AD9CD5097804E6 /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
+		C1B19EC9D9485E170060FE3F /* MockFileRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFileRepository.swift; sourceTree = "<group>"; };
+		C1D3D03F824B5234DB2CE255 /* VoiceInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputViewModel.swift; sourceTree = "<group>"; };
+		C37A177D1938F74CDAA6D30C /* StopVoiceRecordingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopVoiceRecordingUseCase.swift; sourceTree = "<group>"; };
+		C400ADD3AA001DA1105EBDDC /* RFTranscriptionOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFTranscriptionOverlay.swift; sourceTree = "<group>"; };
+		C4C539E69D7EF79983D17D97 /* RFVoiceOutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFVoiceOutputView.swift; sourceTree = "<group>"; };
+		C5E3A66FF0F6E229066CE9A9 /* TTSVoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSVoice.swift; sourceTree = "<group>"; };
+		C7F6D7D2C0636983F1E7E31A /* ProjectStatusDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectStatusDTO.swift; sourceTree = "<group>"; };
+		C92DE3CA5EDCE43142B45794 /* VoiceInputRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputRepositoryProtocol.swift; sourceTree = "<group>"; };
+		C93E0C5E2CB85ADDF4C6157F /* ChatMessageDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageDTO.swift; sourceTree = "<group>"; };
+		CD2D79F44187942A602731BB /* LoginUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCaseTests.swift; sourceTree = "<group>"; };
+		CDB4EC51AF46B7F748D4DDB1 /* WebSocketMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketMessage.swift; sourceTree = "<group>"; };
+		CE63BB82B0AF956CDD1A5B38 /* ProjectDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectDetailViewModel.swift; sourceTree = "<group>"; };
+		CE91FB0E476FF189A678A9DC /* DeviceTokenDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenDTO.swift; sourceTree = "<group>"; };
+		D026E5183E0472546C7337C1 /* RFVoiceInputButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFVoiceInputButton.swift; sourceTree = "<group>"; };
+		D0FDCB895C361FB669FAEE86 /* RFWaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFWaveformView.swift; sourceTree = "<group>"; };
+		D101B741ABFC1B7514DADBFE /* RFLanguageSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFLanguageSelector.swift; sourceTree = "<group>"; };
+		D19403B092F47DC09ADF90B3 /* ApprovalResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalResponseDTO.swift; sourceTree = "<group>"; };
+		D286048B24F11048FAA30AA5 /* RFStepProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFStepProgressView.swift; sourceTree = "<group>"; };
+		D338A67C42C34EA7A5F34CB9 /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
+		D3B7498BA91A02D08B6CA590 /* ApprovalRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalRepositoryProtocol.swift; sourceTree = "<group>"; };
+		D3F113CB582E1708646DC09D /* DownloadFileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFileUseCase.swift; sourceTree = "<group>"; };
+		D5C19344181D70DA7F175D9E /* MockChatRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockChatRepository.swift; sourceTree = "<group>"; };
+		D6500E42A1EC1502F70F2EFB /* AppTabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTabTests.swift; sourceTree = "<group>"; };
+		D6E5613AC09F1BC3C47D904E /* WebSocketMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketMessageTests.swift; sourceTree = "<group>"; };
+		D8DFD891B89F50F8D52363BE /* ChatMessageMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageMapperTests.swift; sourceTree = "<group>"; };
+		D9494F1BB2D75D74A4D23360 /* RFTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFTextTests.swift; sourceTree = "<group>"; };
+		DA3D573C4FCB2B3CA5F38D93 /* ApprovalTestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalTestFactory.swift; sourceTree = "<group>"; };
+		DBDC3315500C75ABF09F2FF1 /* UserProfileMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileMapper.swift; sourceTree = "<group>"; };
+		DCE433D8C6C908371422E9E3 /* ProjectDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectDetailView.swift; sourceTree = "<group>"; };
+		DD43B55D9F303CA181C0D313 /* VoiceLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceLanguage.swift; sourceTree = "<group>"; };
+		DEF111423ECD9DF6A6D28803 /* VoiceInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputViewModelTests.swift; sourceTree = "<group>"; };
+		DFA6E443317BC57250C82113 /* ProgressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewModel.swift; sourceTree = "<group>"; };
+		E06F075CD564B7C9B302F557 /* MockProgressRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProgressRepository.swift; sourceTree = "<group>"; };
+		E123D689391F5EDCB9E1D919 /* ApprovalCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalCardViewModelTests.swift; sourceTree = "<group>"; };
+		E1A233B6173D693D3E16616C /* DeepgramMessageDTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepgramMessageDTOTests.swift; sourceTree = "<group>"; };
+		E1E81483960598B0E4BA4ECD /* StartVoiceRecordingUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartVoiceRecordingUseCaseTests.swift; sourceTree = "<group>"; };
+		E4813BF26B2B15D0D2CA06EB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E4D0B1722F9261441B62830E /* AppLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogger.swift; sourceTree = "<group>"; };
+		E57A611E9759F629A8F4C5ED /* VoiceInputTestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputTestFactory.swift; sourceTree = "<group>"; };
+		E6016664D42539CA3682B2BB /* RFText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFText.swift; sourceTree = "<group>"; };
+		E6124D6E1DECAB58D50AE8B0 /* View+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extensions.swift"; sourceTree = "<group>"; };
+		E745D17E31094BA30A4732FD /* ProjectRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectRepositoryImpl.swift; sourceTree = "<group>"; };
+		EA8C45FE6EB4CB9BC35B709B /* VoiceOutputState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOutputState.swift; sourceTree = "<group>"; };
+		EAC60F0C5E533BCE8BA4A67A /* LoadSettingsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadSettingsUseCase.swift; sourceTree = "<group>"; };
+		EC6A2CB9D986C62030FB1136 /* RFTextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFTextFieldTests.swift; sourceTree = "<group>"; };
+		ECA00A07C3581E3EFC1510B0 /* HandleNotificationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleNotificationUseCase.swift; sourceTree = "<group>"; };
+		ED988AF5D675A2192F7CABF4 /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
+		EE3260EBF20616C55A22A28A /* FileDTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDTOTests.swift; sourceTree = "<group>"; };
+		EE99A9CC802FA53865A170A8 /* VoiceInputState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputState.swift; sourceTree = "<group>"; };
+		EED8584735CB9CC73F0A3192 /* LoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCase.swift; sourceTree = "<group>"; };
+		F03CACBAE25C8A38ECF7B45C /* ChatViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModelTests.swift; sourceTree = "<group>"; };
+		F1C39109AD4B14FB902DDDE1 /* RFProjectStatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFProjectStatusBadge.swift; sourceTree = "<group>"; };
+		F2198BE7D92A94C10AAE85AD /* ProgressMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressMapperTests.swift; sourceTree = "<group>"; };
+		F252D49D3EC1D709A56B1673 /* RFCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFCard.swift; sourceTree = "<group>"; };
+		F2DD29420857C3A0B3A13879 /* StopPlaybackUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopPlaybackUseCase.swift; sourceTree = "<group>"; };
+		F2F36517B94A8021E276737B /* TTSMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSMapperTests.swift; sourceTree = "<group>"; };
+		F41AA8948BA168061C1A7693 /* ProgressRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressRepositoryImpl.swift; sourceTree = "<group>"; };
+		F503BC69A6F011BBD9C5C7A1 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
+		F50CEA586C89F51C32CEF461 /* RFTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFTextField.swift; sourceTree = "<group>"; };
+		F5224B55A7BB421788157E25 /* ProgressModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressModelTests.swift; sourceTree = "<group>"; };
+		F5E0B9813123EAFCAF6E5425 /* RafRafApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RafRafApp.swift; sourceTree = "<group>"; };
+		F5F752599A11956764AC8B10 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
+		F653780F1553EA39EC97C85E /* ChatRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRepositoryProtocol.swift; sourceTree = "<group>"; };
+		F7561424D168B690C0D88BA1 /* ChatMessageMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageMapper.swift; sourceTree = "<group>"; };
+		F7907F9B240D2B0A7723AFE0 /* AppContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppContainer.swift; sourceTree = "<group>"; };
+		F8C9DD548ED813FFD84304A3 /* RFScreenshotFullScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFScreenshotFullScreenView.swift; sourceTree = "<group>"; };
+		F91B37544AF71EF06D1F7BC4 /* NotificationCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCategory.swift; sourceTree = "<group>"; };
+		FB2AC6DDCE2301CABD2110DC /* AuthRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRepositoryImpl.swift; sourceTree = "<group>"; };
+		FBFE526FB9C651EB7DCE792E /* TTSVoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSVoiceTests.swift; sourceTree = "<group>"; };
+		FD5A0CEEA28B2E01F3408A9A /* ChatAttachmentDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentDTO.swift; sourceTree = "<group>"; };
+		FDF2C47869AE1620A3BBEC2A /* ApprovalMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalMapper.swift; sourceTree = "<group>"; };
+		FE2DD0C74D5C60819C75A400 /* AudioLevelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioLevelTests.swift; sourceTree = "<group>"; };
+		FF3E05119E588957102E442F /* AuthMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthMapper.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		294563B3FAF7BDC7BC596440 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FE9DD255E14A8684F283232B /* Factory in Frameworks */,
+				B534868086435D4FBA4D0090 /* Nuke in Frameworks */,
+				898671F42572DA368D1C6997 /* NukeUI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		002A0A65959CFD8B19386432 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				525558CAE23C387B75FB9154 /* RFButtonTests.swift */,
+				873A95A473C0B0BC9B36ACED /* RFCardTests.swift */,
+				EC6A2CB9D986C62030FB1136 /* RFTextFieldTests.swift */,
+				D9494F1BB2D75D74A4D23360 /* RFTextTests.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		006DDF40AB4F6D10FE332CF8 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				187375870FE1385F61CC29DA /* NotificationMapperTests.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		011C82C62581BEC3BE838891 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				975ABDD02BBE17015B5B12B8 /* SettingsViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		01D90EE7F61EE7F50E3BFB9C /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				641832E6F66AE3616A9185A2 /* Models */,
+				44EC5B73C362753F1034649E /* Repositories */,
+				397064570F16CE81428D1420 /* UseCases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		055E28D940E02DA439783890 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				B71E90843FD467D2984DD9E9 /* RFFileAttachmentCard.swift */,
+				88F05B616E16FF794F92E424 /* RFUploadProgressView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		0569E193F47F2E1CEB1EC457 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				91541D471DBA109AA6FADD7B /* RafRaf.app */,
+				429F7CAB9685E8ABE03DB4E0 /* RafRafTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		05AB44882E53DCF61F58FA77 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				215C7199300B4BE5F1DB5D5A /* ScreenshotRepositoryProtocol.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		06060BFC8E133B999A7E184F /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				80169C157CC966EDF67F923F /* VoiceOutputViewModelTests.swift */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		084B9376BE7AA9554D5277D7 /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				18F6A7FF298FF847CDAE8333 /* BiometricLoginUseCase.swift */,
+				EED8584735CB9CC73F0A3192 /* LoginUseCase.swift */,
+				B4770214A1452EB574E607F2 /* LogoutUseCase.swift */,
+				9B6B7BA7869125371EA75C10 /* RefreshTokenUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		08A29D80106AB241785BA94F /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				26E40E45FC70F75C1A03072E /* HandleNotificationUseCaseTests.swift */,
+				384E4B954363B2EE0FDCDB7C /* NotificationCategoryTests.swift */,
+				249EF47971A35E816A840720 /* NotificationRouterTests.swift */,
+				BAC11AC16AFB4F0AE3B6291D /* RegisterDeviceTokenUseCaseTests.swift */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		0BF99648123F4D0304A41342 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				319FC08A12062D681D3865ED /* ApprovalOption.swift */,
+				7CCE0E6590187D6D085DD904 /* ApprovalQuestion.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		0D5B69EEA31D249589089CD7 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				08F03CE4C7201D9AFD3FA1D1 /* ScreenshotViewerViewModelTests.swift */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		0E453DD8447373BA16B208A4 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				379099FF7A346C1A45E43D0A /* AuthRepository.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		0EBB6EB2E19C22BE47971CA2 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				87C5EB5410DB1CD92C7780F4 /* RFVoiceInputView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		0EC84D3332699CFC87E7FC8E /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				6E5B2EDFD388B80900006C19 /* ApprovalQuestionDTO.swift */,
+				D19403B092F47DC09ADF90B3 /* ApprovalResponseDTO.swift */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		0F10C710162ADC133159A4ED /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				4BD2FB07F7129641203B25A3 /* ProjectStatusMapperTests.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		11C518E06A02BB9DB76AF490 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				554FB5635202438D8C671256 /* AuthMapperTests.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		12EA9B89AE81E62A5BD572B4 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				4EB9277F8FB5FF307653B2DB /* SettingsRepositoryImpl.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		14D3DCBD2B4E836B608B57EA /* ScreenshotViewer */ = {
+			isa = PBXGroup;
+			children = (
+				6805E6288174ED9A40AC2820 /* Data */,
+				C4507A0FE0601CD7FB73158F /* Domain */,
+				17BE9BABB433A0D76D8C7EA5 /* Presentation */,
+			);
+			path = ScreenshotViewer;
+			sourceTree = "<group>";
+		};
+		17BE9BABB433A0D76D8C7EA5 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				D3211E0CD8113354C4F74A5E /* Components */,
+				5CBC9A949C1B1FC3E3017EA9 /* ViewModels */,
+				CD7F1701EF1339281E066E55 /* Views */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		188C2CD1E0213D9083BBABDC /* RafRaf */ = {
+			isa = PBXGroup;
+			children = (
+				4DDE9A2B7D05F73EA7526AA7 /* Info.plist */,
+				23F6289650B08B9B1F24A400 /* App */,
+				9890CD153671722A9246B1A5 /* Core */,
+				BC79E32E698EC0413104F0D7 /* DesignSystem */,
+				5CE05B104E13CE174FE774E9 /* Features */,
+				8B24BCBD10FFE7C46EA40FF2 /* Resources */,
+			);
+			path = RafRaf;
+			sourceTree = "<group>";
+		};
+		1A3741B0F74788FC8AE9DDC9 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				ED988AF5D675A2192F7CABF4 /* HomeViewModelTests.swift */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		1A5BE22C4208EC75483809E9 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				E06F075CD564B7C9B302F557 /* MockProgressRepository.swift */,
+				2F3EBF23EE03D49A6FCB28F2 /* ProgressTestFactory.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		1C29DFDED6B57F4E06699E7E /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				154B32F3E66E7DD27646B928 /* ApprovalRepositoryImpl.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		1D96F6CAB7F77B538976FA99 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				822D1B3519782E19AAE6B807 /* RFAvatar.swift */,
+				2B6378F006F2E44C0E575BBC /* RFButton.swift */,
+				F252D49D3EC1D709A56B1673 /* RFCard.swift */,
+				9B14A5823261777D9A44ECCE /* RFEmptyStateView.swift */,
+				73EDDECB3A8862452651E8E2 /* RFErrorView.swift */,
+				747F8B6AF88D6C525824A2B4 /* RFLoadingView.swift */,
+				E6016664D42539CA3682B2BB /* RFText.swift */,
+				F50CEA586C89F51C32CEF461 /* RFTextField.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		20E314299F9CE126FBE89C2E /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				6E1F0F7CC8A6587BBC8BDF97 /* ViewModels */,
+				86F04D711C713F9E2B1F60CC /* Views */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		21D47D44CC63EE70D29B81BA /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				B971BB8F0A8579AB206FAE7C /* VoiceOutputViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		2270A56D5AA4C2E3A045F6AE /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				37FFD418418E0FE4B18EFF0A /* SettingsTestFactory.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		227C037F767A5A17E3C2C934 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				DEF111423ECD9DF6A6D28803 /* VoiceInputViewModelTests.swift */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		2346CA331F0330DC8FB097FD /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				7F742FCF558A34BDC0E65CC3 /* AuthViewModelTests.swift */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		23AE27255805D9062B25F6F3 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				81462513B22C5B10107DE1C8 /* LoadScreenshotUseCaseTests.swift */,
+				207A34477514118FB3C20E6C /* ScreenshotModelTests.swift */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		23F6289650B08B9B1F24A400 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				E4813BF26B2B15D0D2CA06EB /* AppDelegate.swift */,
+				3B1ADDEFA8694886A954995E /* AppEnvironment.swift */,
+				4F64086A1002320F2E9FF4D3 /* ContentView.swift */,
+				F5E0B9813123EAFCAF6E5425 /* RafRafApp.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		25D6A0A56D2F70FA7FCDF5EE /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				71B262091F1518F1D4513B24 /* UserProfileDTO.swift */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		27C2C8D35DF1863D6D75A0CB /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				2BB47CD519D01037848C453D /* Screenshot.swift */,
+				51194784C4D4A291F0B8CEAE /* ScreenshotViewerState.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		2874D38FE863E4B978F51169 /* Progress */ = {
+			isa = PBXGroup;
+			children = (
+				E8E3AC9F24054511B2492F3E /* Data */,
+				C04F67BE5D05920BDFD0CA6C /* Domain */,
+				1A5BE22C4208EC75483809E9 /* Mocks */,
+				41F22612276E502D7007AB97 /* Presentation */,
+			);
+			path = Progress;
+			sourceTree = "<group>";
+		};
+		2AB3DEF8486E7338DC7A094D /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				46D8A55FE9AF917427DE9BBB /* ChatMessageModelTests.swift */,
+				F03CACBAE25C8A38ECF7B45C /* ChatViewModelTests.swift */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		2E124DE23AF5BE1C2038BF04 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				E745D17E31094BA30A4732FD /* ProjectRepositoryImpl.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		2F00290C788FD1FDC83FF939 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				931D9E17D14411A86B006D64 /* Components */,
+				DCFAD1D7C273AFA57C032AA9 /* ViewModels */,
+				FD5C5788FDB49E89C5299E71 /* Views */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		2F2DDE1FEF449AF745009853 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				363B74F897CDBED36B83D849 /* ProgressView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		2F646050A636D48116924D8F /* VoiceOutput */ = {
+			isa = PBXGroup;
+			children = (
+				FBA3FCBCCE3B469668C0CC82 /* Data */,
+				97B0786FF8DBE2201D052EA3 /* Domain */,
+				E14C7822C08AEEEF0266CF92 /* Presentation */,
+			);
+			path = VoiceOutput;
+			sourceTree = "<group>";
+		};
+		2F93C278672D7B028DD3B802 /* VoiceOutput */ = {
+			isa = PBXGroup;
+			children = (
+				C0D37D5BE3249E2E9E8CC4A3 /* Data */,
+				C5870DD825D1A969D44FFA8B /* Domain */,
+				56CF78240AF26842CE79ECC5 /* Helpers */,
+				5239D3D4DEEA9513E7165E63 /* Mocks */,
+				06060BFC8E133B999A7E184F /* Presentation */,
+			);
+			path = VoiceOutput;
+			sourceTree = "<group>";
+		};
+		30663F21EE8552A3A8BF582A /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				C4C539E69D7EF79983D17D97 /* RFVoiceOutputView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		3285F82E0B01932D835642AE /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				B7BDBED213305ACA70334DBA /* ChatRepositoryImpl.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		34870A0A725E76B1A20C817C /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				82705500948A44192CC29295 /* MockScreenshotRepository.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		34B76F5DDDC98EB6CDC179A9 /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				45E08A5F59D1C2E500A03406 /* FileDownloadResponseDTO.swift */,
+				4BFD733653E0525C72ACFCB1 /* FileMetadataDTO.swift */,
+				95B7966D42658E0B614C3900 /* FileUploadRequestDTO.swift */,
+				00C758CB8053C9CF929DA33B /* FileUploadResponseDTO.swift */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		357F4969DF1306EBD33806E4 /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				ECA00A07C3581E3EFC1510B0 /* HandleNotificationUseCase.swift */,
+				66E9B6A86D86A85928EC43D4 /* RegisterDeviceTokenUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		370CAF99110CEE34B4C86935 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				0D35E8474601420710ED6CA8 /* GetProjectsUseCaseTests.swift */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		37197300D6C9A0509E567808 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				0BF99648123F4D0304A41342 /* Models */,
+				CCAF4A603061081A9FE38741 /* Repositories */,
+				69053DF410BD83355F4A3910 /* UseCases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		397064570F16CE81428D1420 /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				D3F113CB582E1708646DC09D /* DownloadFileUseCase.swift */,
+				5A65E5F15056A62DCEC6C111 /* UploadFileUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		3A77F862DE4FA2A7B45B20CC /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				0ECFBBAEFFE940FB82263775 /* RFColors.swift */,
+				58B5C79F81BBBAB0FC37BF61 /* RFSpacing.swift */,
+				2839C39830CCECEE80290942 /* RFTypography.swift */,
+			);
+			path = Theme;
+			sourceTree = "<group>";
+		};
+		3AB8D2BC83D07BF369195A17 /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				FA1C8D64AB66249AE95FE258 /* Data */,
+				3E47EB82D62CD572AC97E765 /* Domain */,
+				A1841014BFE288EF0AC512F6 /* Presentation */,
+			);
+			path = Notifications;
+			sourceTree = "<group>";
+		};
+		3C40B159CCF466173FD5ECDF /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				334E232A5C84D86BF0C4487A /* GetProjectDetailUseCase.swift */,
+				0FADD172BD04821AA0F68F16 /* GetProjectsUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		3E471E4FA3CF93D589C2A7AA /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				C276EA0275D6BEE9A683C83E /* Models */,
+				0E453DD8447373BA16B208A4 /* Repositories */,
+				084B9376BE7AA9554D5277D7 /* UseCases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		3E47EB82D62CD572AC97E765 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				BA7EAFCA5E157FBEA23C283A /* Models */,
+				B30927AC3DD63B19D7206057 /* Repositories */,
+				357F4969DF1306EBD33806E4 /* UseCases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		3F0FA47DE12760C99F6BCE6E /* Approval */ = {
+			isa = PBXGroup;
+			children = (
+				85C189F6284E2EF49BF1FF04 /* Data */,
+				FB875E802416E149FADB9DE3 /* Domain */,
+				B05CA43F814662E55E207FD7 /* Helpers */,
+				B8271DA014C9CEE0F6F1D468 /* Mocks */,
+				A56EC8A02A663464548474EE /* Presentation */,
+			);
+			path = Approval;
+			sourceTree = "<group>";
+		};
+		3F349111E0DC309853A714A5 /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				EAC60F0C5E533BCE8BA4A67A /* LoadSettingsUseCase.swift */,
+				79C9096623185819E65CA1D7 /* SaveSettingsUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		418E13AAD7D4B49E29E017F2 /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+				C0ACC5410D3BAB6F979A08BF /* ScreenshotMapper.swift */,
+			);
+			path = Mappers;
+			sourceTree = "<group>";
+		};
+		41F22612276E502D7007AB97 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				8B726893F6FD86DF7513707C /* ProgressViewModelTests.swift */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		42DF21E27F158F4D8582C424 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				546AAC0031A9F77C1AF58B6B /* RFFilePickerView.swift */,
+				2DDAA4E5F9C097B9A0DCD3ED /* RFFilePreviewView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		44EC5B73C362753F1034649E /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				AD6B51A4354CBB85A0314750 /* FileRepositoryProtocol.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		46847796711C93DA06BAF33B /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				A28FA43D580A4C8DCD750BFD /* NetworkClient.swift */,
+				9D1BED62AE03EC1F750E0D07 /* WebSocketClient.swift */,
+				48E6F1382915379B3048B07A /* WebSocketConnectionManager.swift */,
+				CDB4EC51AF46B7F748D4DDB1 /* WebSocketMessage.swift */,
+				0562ABFC489C98DF5B80B11F /* WebSocketMessageRouter.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		46D26786551CCBE70015AB7F /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				F2DD29420857C3A0B3A13879 /* StopPlaybackUseCase.swift */,
+				C14699F016E8A261A536C426 /* SynthesizeSpeechUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		46D7DC1A5B867D6929829BC4 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				9A681B9DE77FED4F72FFE999 /* FileRepositoryImpl.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		487B8C3FC0ECA6228EB6187D /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				371ADE781BE1D773A3E1CD89 /* RFLoginView.swift */,
+				21C674551BDF23B45BDDEEA1 /* RFRegisterView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		49D8925FD3E04F5821CA1D8D /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				715707FA419F42EBE2606B73 /* Data */,
+				1A3741B0F74788FC8AE9DDC9 /* Presentation */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		4A92EF35966FCBA8EDD0C9C4 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				FE2DD0C74D5C60819C75A400 /* AudioLevelTests.swift */,
+				E1E81483960598B0E4BA4ECD /* StartVoiceRecordingUseCaseTests.swift */,
+				25274F3184E417CDB72FDE2A /* VoiceInputStateTests.swift */,
+				957F7F221FCC3D03CD9A40FD /* VoiceLanguageTests.swift */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		4D9C05C7E0C44D79ECDA95B1 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				0617A5997B3B90CE3D2AE134 /* RFChatInput.swift */,
+				20CD7C997F970FBA36D3C074 /* RFCodeBlock.swift */,
+				9B3C516BC231E3C69265CF80 /* RFImageMessageView.swift */,
+				B0F0C7A8C0EB877BF24E6FE1 /* RFMessageBubble.swift */,
+				3B34887B85ED882C16492C16 /* RFTypingIndicator.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		4E2AF205AF92EE8F566AA731 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				517B68594F651F57917C24EE /* TTSAudioCache.swift */,
+				9451177087744E75E0DBE274 /* VoiceAudioPlayer.swift */,
+				6EA20ABC96037E772A9A2BE7 /* VoiceOutputRepositoryImpl.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		4E318912CF067AF8DC01FC28 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				71E5CDE0818B65FC99E6FA96 /* Models */,
+				9086A181F0B63872E9B14E2F /* Repositories */,
+				3F349111E0DC309853A714A5 /* UseCases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		4E8536BC8150458C6A19C167 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				07256F747ADB59F141BD6018 /* TTSAudioResult.swift */,
+				96967D0E131F879DD93C6911 /* TTSRequest.swift */,
+				C5E3A66FF0F6E229066CE9A9 /* TTSVoice.swift */,
+				EA8C45FE6EB4CB9BC35B709B /* VoiceOutputState.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		4F73BA5C81827A3A4BE7B5F7 /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				45410A8C9586B7AC9E5F0343 /* ProjectDTO.swift */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		5239D3D4DEEA9513E7165E63 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				9B4F745C0108B4145E7EF263 /* MockVoiceAudioPlayer.swift */,
+				6D0BF27553B9D15937606D9D /* MockVoiceOutputRepository.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		53543F25197AF8EA472B4094 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				5E52C0850223ADA5F2594D99 /* DownloadFileUseCaseTests.swift */,
+				98519EB95B9F99313A9D3793 /* SupportedFileTypeTests.swift */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		54DDAFE31476559E4B59F6A9 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				F653780F1553EA39EC97C85E /* ChatRepositoryProtocol.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		5561F4DEE7688E31841105C0 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				82E989E4962D885164F6CACA /* LoadChatHistoryUseCaseTests.swift */,
+				93269E459ED3188CC38BD6A0 /* SendMessageUseCaseTests.swift */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		55AC8304EDC7E348A0DE8270 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				C92DE3CA5EDCE43142B45794 /* VoiceInputRepositoryProtocol.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		55C3FB090184336CC0CA4EE2 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				084B22FA750C796D020FA70D /* FilePickerViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		56C4772545FFC1AE452C623A /* RafRafTests */ = {
+			isa = PBXGroup;
+			children = (
+				D6500E42A1EC1502F70F2EFB /* AppTabTests.swift */,
+				B77ECD792247535700E2AE98 /* RafRafTests.swift */,
+				8362F950F517192B035DB673 /* Core */,
+				DEEFC5BD00D95B7499D508B1 /* DesignSystem */,
+				A1A6B05FEFFC44B49F573F9B /* Features */,
+			);
+			path = RafRafTests;
+			sourceTree = "<group>";
+		};
+		56CF78240AF26842CE79ECC5 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				9425CF331038E45CABFF6BFE /* VoiceOutputTestFactory.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		58309D66B6CA8F7EA9CC9923 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				C187324456AD9CD5097804E6 /* AuthInterceptor.swift */,
+				884DCBB378AB332BCCE7C7E3 /* AuthManager.swift */,
+				92E34C797F5A1B904C7BE6DE /* BiometricAuthManager.swift */,
+				1C365DE11989085900D374D8 /* KeychainHelper.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		58BF24274BDDFD0EE058DBAC /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				D8DFD891B89F50F8D52363BE /* ChatMessageMapperTests.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		58CFEF47BF445F3AFDA99592 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				ECB39E431C8078170FC1EF7C /* Components */,
+				9176AF125F10F6395433CDA8 /* ViewModels */,
+				487B8C3FC0ECA6228EB6187D /* Views */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		5CBC9A949C1B1FC3E3017EA9 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				8A066A9189723C78D76BD8E1 /* ScreenshotViewerViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		5CE05B104E13CE174FE774E9 /* Features */ = {
+			isa = PBXGroup;
+			children = (
+				CFD22DA06A96016F7C96E4DE /* Approval */,
+				95CF02677BA990463DE21AF3 /* Auth */,
+				D63817B372E2117ECFD9F8B8 /* Chat */,
+				FB2779B4FCE83EBBA2D09B1F /* FileSharing */,
+				D14F9A966DB22E931488DEE9 /* Home */,
+				3AB8D2BC83D07BF369195A17 /* Notifications */,
+				BBDE6C74FF67C05B890B003E /* Progress */,
+				C1C761F83B1C8F02C519D859 /* Project */,
+				14D3DCBD2B4E836B608B57EA /* ScreenshotViewer */,
+				999A713F8A35978D08F63332 /* Settings */,
+				BA2A91070A4308BCC44C1053 /* VoiceInput */,
+				2F646050A636D48116924D8F /* VoiceOutput */,
+			);
+			path = Features;
+			sourceTree = "<group>";
+		};
+		5DD9A7473C765C12598D89BF /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				11C518E06A02BB9DB76AF490 /* Data */,
+				6CDFED45D96BE0BECD013C5A /* Domain */,
+				892A0761A5A17FF25F51674D /* Mocks */,
+				2346CA331F0330DC8FB097FD /* Presentation */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		5F9538053E30FF09EAFF7F0A /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				66AA94B64F205036F8707946 /* ProjectDetailViewModelTests.swift */,
+				180F43D46C4EF6B37661F039 /* ProjectListViewModelTests.swift */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		60A49E2DB4FA240E7690B242 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				726CA7D2B12A8012E6CEA268 /* ProjectStatusRepository.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		63E9069C1A178013B54DD75A /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				599BD9251B142BAAB1AB3243 /* VoiceOutputRepositoryProtocol.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		641832E6F66AE3616A9185A2 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				A95DA37617833E9ED55D85BC /* FileUploadProgress.swift */,
+				873D341B8899DEFD0E0C6017 /* SharedFile.swift */,
+				58E9BF74CBB3574A290E0605 /* SupportedFileType.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		648CACB9728824F9BAF5E0B6 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				AB738373DA1F70E1CC51B98D /* DTOs */,
+				A10B50CF66DF5FC12882DD52 /* Mappers */,
+				7E1D666B38C66F557D98B930 /* Repositories */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		64AE3B2E7F1F843FB195A526 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				3B841E5C35A563010F7F8A41 /* SettingsRepositoryImplTests.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		653271132DB8F0E409D3B3D8 /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				0DD4187290AB38FC00C47889 /* ScreenshotDTO.swift */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		654C71B37464BF83B3796651 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				EE3260EBF20616C55A22A28A /* FileDTOTests.swift */,
+				BF7CAEA24922BEBB6FB0C1BE /* FileMapperTests.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		6784BE2CDCB1872419F659DA /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				036FEC3776B23ACDD23096FA /* MockSettingsRepository.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		67B58EC2D7DE29D142036D6B /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+				FDF2C47869AE1620A3BBEC2A /* ApprovalMapper.swift */,
+			);
+			path = Mappers;
+			sourceTree = "<group>";
+		};
+		6804DCF41ED03AD6C80FAA2A /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				80239C7F3737C3A1728A2907 /* DTOs */,
+				A6ADA4AAE554E81E6EDC3135 /* Mappers */,
+				E6EB440AB200FE75366DB3B5 /* Repositories */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		6805E6288174ED9A40AC2820 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				653271132DB8F0E409D3B3D8 /* DTOs */,
+				418E13AAD7D4B49E29E017F2 /* Mappers */,
+				C146D6C56124A8C3A2206A9C /* Repositories */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		69053DF410BD83355F4A3910 /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				8CA61012D78580A68D7F7FD5 /* SubmitApprovalDecisionUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		69F70840057CE5DF1ECEA04C /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				2AD7EB1A7F663F2AE599276F /* ScreenshotDTOTests.swift */,
+				6B2D1ED44EF7C4C281C1C692 /* ScreenshotMapperTests.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		6B2F90E46EDA98C165F6F763 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				0091DFD4063859F7357A52EF /* RFNotificationBanner.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		6BB1CB51C38CDDF0638D75CE /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				3EFD5ABF35F2A79B997B8A09 /* RFApprovalCard.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		6CDFED45D96BE0BECD013C5A /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				CD2D79F44187942A602731BB /* LoginUseCaseTests.swift */,
+				B4BD449523E0B3C3C0E599A8 /* RefreshTokenUseCaseTests.swift */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		6E1F0F7CC8A6587BBC8BDF97 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				1F9EF868FB8B3129126B6185 /* HomeViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		70422777612855BADAA2A717 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				BC28F395365755DC07DC227A /* RFProgressIndicator.swift */,
+				D286048B24F11048FAA30AA5 /* RFStepProgressView.swift */,
+				38D3D086D405CEE09599451F /* RFToolStatusView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		7154213E0D87EAD17D1358BF /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				0D27E77CD6F518CFAFDCBEF2 /* RFApprovalOptionButton.swift */,
+				2E90391D47DE86AFCDF0FE1D /* RFCountdownTimer.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		715707FA419F42EBE2606B73 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				BCFB318AF6289ED14E926848 /* ProjectMapperTests.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		71E5CDE0818B65FC99E6FA96 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				5992E0A0F127905160F54939 /* AppSettings.swift */,
+				012C760BCD578912C69FF278 /* UserProfile.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		73FBDA34D6D6C8F61A2349CB /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				9A562DDCF69C71C851CB6ADE /* Models */,
+				54DDAFE31476559E4B59F6A9 /* Repositories */,
+				AAB9E670EE53446ED80B35E3 /* UseCases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		7587E42BF680BC43A58FFF0C /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				F503BC69A6F011BBD9C5C7A1 /* ChatView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		75E0C4D168863ADB21A4F0A0 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				70422777612855BADAA2A717 /* Components */,
+				BF6BA117E8E963163AED3A37 /* ViewModels */,
+				2F2DDE1FEF449AF745009853 /* Views */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		77C1049FB4E371092B257E83 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				A2651903EEF68D395535F775 /* SettingsViewModelTests.swift */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		79D234B772B3550DB7089BC6 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				0EC84D3332699CFC87E7FC8E /* DTOs */,
+				67B58EC2D7DE29D142036D6B /* Mappers */,
+				1C29DFDED6B57F4E06699E7E /* Repositories */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		7C1DF105EF3AA515D571A8A5 /* Voice */ = {
+			isa = PBXGroup;
+			children = (
+				839DFFD5CDFE6D3EA5CC1B8A /* RFAudioSessionManager.swift */,
+				41ED0F098D2B09B8912AA1BF /* RFSpeechRecognizer.swift */,
+			);
+			path = Voice;
+			sourceTree = "<group>";
+		};
+		7DDF8E9B71C8CD499B5CD809 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				A8BC517FE8F386693CAEE3FF /* ProgressState.swift */,
+				29C9C9B4827904B306AD71B5 /* ProgressStep.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		7E1D666B38C66F557D98B930 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				FB2AC6DDCE2301CABD2110DC /* AuthRepositoryImpl.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		80239C7F3737C3A1728A2907 /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				9999729875223B6921FC95AB /* ProgressEventDTO.swift */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		81CA7D86D04DDD264AE0C7AC /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				C1D3D03F824B5234DB2CE255 /* VoiceInputViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		8218A28AA23789A29B4070CE /* Project */ = {
+			isa = PBXGroup;
+			children = (
+				0F10C710162ADC133159A4ED /* Data */,
+				370CAF99110CEE34B4C86935 /* Domain */,
+				FCC9D01BD2C91A6FB0C2EC59 /* Mocks */,
+				5F9538053E30FF09EAFF7F0A /* Presentation */,
+			);
+			path = Project;
+			sourceTree = "<group>";
+		};
+		8362F950F517192B035DB673 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				BED0A96AFC6C569770CA9F6F /* Auth */,
+				8B56F604F438FBD85F058487 /* Networking */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		85C189F6284E2EF49BF1FF04 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				422F209F30ED7BFB450E98E0 /* ApprovalMapperTests.swift */,
+				88476BCA795924931C66A42B /* ApprovalQuestionDTOTests.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		861FC01286FCBF2C7798215C /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				5D34BFB48FE8E9FCA8D65AA6 /* TTSRequestDTO.swift */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		8677DAF1E168E22582BBC410 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				09D92C29137D78716255B365 /* ProgressRepositoryProtocol.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		86F04D711C713F9E2B1F60CC /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				08BDCE9F985E5AFB0A26ABCB /* HomeView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		8875A2614B1B2A658EA924CA /* DI */ = {
+			isa = PBXGroup;
+			children = (
+				F7907F9B240D2B0A7723AFE0 /* AppContainer.swift */,
+			);
+			path = DI;
+			sourceTree = "<group>";
+		};
+		892A0761A5A17FF25F51674D /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				B00D12AD59FE69B29E947D16 /* MockAuthRepository.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		8B24BCBD10FFE7C46EA40FF2 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		8B56F604F438FBD85F058487 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				21F39AF4256F417AE5C96B4E /* WebSocketClientTests.swift */,
+				A3867BA8F67E75819B7F8B40 /* WebSocketConnectionManagerTests.swift */,
+				1212FBA12B30AFF5733A8267 /* WebSocketMessageRouterTests.swift */,
+				D6E5613AC09F1BC3C47D904E /* WebSocketMessageTests.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		8B9F452494BE50F8C5409E82 /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				844C2FAAA839BD62A7A4E1F4 /* ObserveProgressUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		8E6E6E37434CABC6B4375D1E /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				3E53636BACB18D634E302F01 /* MockNotificationRepository.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		9086A181F0B63872E9B14E2F /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				3DFC704C8E7E3FCFAA61D0D8 /* SettingsRepositoryProtocol.swift */,
+				918A3F002FFBE2BE8D9EB4F5 /* UserRepositoryProtocol.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		9176AF125F10F6395433CDA8 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				F5F752599A11956764AC8B10 /* AuthViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		929417798FEB8917C76E4098 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				31DD15C6A064EF730978BCC3 /* ApprovalCardViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		92A99870133EB07AC167ACC8 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				4D9C05C7E0C44D79ECDA95B1 /* Components */,
+				C55D7F60C0C7995ABA17C11E /* ViewModels */,
+				7587E42BF680BC43A58FFF0C /* Views */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		931D9E17D14411A86B006D64 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				A60848B934A2BFAEBE6FBD0F /* RFProjectCard.swift */,
+				F1C39109AD4B14FB902DDDE1 /* RFProjectStatusBadge.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		95CF02677BA990463DE21AF3 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				648CACB9728824F9BAF5E0B6 /* Data */,
+				3E471E4FA3CF93D589C2A7AA /* Domain */,
+				58CFEF47BF445F3AFDA99592 /* Presentation */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		974D0DBB491F40017800F71A /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+				DBDC3315500C75ABF09F2FF1 /* UserProfileMapper.swift */,
+			);
+			path = Mappers;
+			sourceTree = "<group>";
+		};
+		97B0786FF8DBE2201D052EA3 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				4E8536BC8150458C6A19C167 /* Models */,
+				63E9069C1A178013B54DD75A /* Repositories */,
+				46D26786551CCBE70015AB7F /* UseCases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		9890CD153671722A9246B1A5 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				58309D66B6CA8F7EA9CC9923 /* Auth */,
+				8875A2614B1B2A658EA924CA /* DI */,
+				D6E529154A3F1E39AE3D1E9B /* Extensions */,
+				CB7A3F66AE349BEBC81EEF0D /* Logging */,
+				46847796711C93DA06BAF33B /* Networking */,
+				BF2C977A8D58E6C89567562F /* Notifications */,
+				7C1DF105EF3AA515D571A8A5 /* Voice */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		98F2F4EA4F9814837DF581E7 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				4F73BA5C81827A3A4BE7B5F7 /* DTOs */,
+				E1A61BB04368FE734AA4F7B3 /* Mappers */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		999A713F8A35978D08F63332 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				DB8C94EC5834DEEF693C7349 /* Data */,
+				4E318912CF067AF8DC01FC28 /* Domain */,
+				BB912EB55B8BF50EE07DA94D /* Presentation */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		9A562DDCF69C71C851CB6ADE /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				1B5D1C4CC76AA7F60B425026 /* ChatAttachment.swift */,
+				B3DCF48D283B68256FE6AD03 /* ChatMessage.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		9C3924380667E803AC24E6E8 /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				006DDF40AB4F6D10FE332CF8 /* Data */,
+				08A29D80106AB241785BA94F /* Domain */,
+				8E6E6E37434CABC6B4375D1E /* Mocks */,
+			);
+			path = Notifications;
+			sourceTree = "<group>";
+		};
+		9D5C6E6476A38E0C37F672A0 /* ScreenshotViewer */ = {
+			isa = PBXGroup;
+			children = (
+				69F70840057CE5DF1ECEA04C /* Data */,
+				23AE27255805D9062B25F6F3 /* Domain */,
+				BF2FE0A126F4B98B04E6406C /* Helpers */,
+				34870A0A725E76B1A20C817C /* Mocks */,
+				0D5B69EEA31D249589089CD7 /* Presentation */,
+			);
+			path = ScreenshotViewer;
+			sourceTree = "<group>";
+		};
+		9F0D61BADBB49F4A3C4FE540 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				7154213E0D87EAD17D1358BF /* Components */,
+				929417798FEB8917C76E4098 /* ViewModels */,
+				6BB1CB51C38CDDF0638D75CE /* Views */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		A06E724D119E594A88E15630 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				472146B7B4BACE8CAD4276BA /* VoiceInputRepositoryImpl.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		A10B50CF66DF5FC12882DD52 /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+				FF3E05119E588957102E442F /* AuthMapper.swift */,
+			);
+			path = Mappers;
+			sourceTree = "<group>";
+		};
+		A1841014BFE288EF0AC512F6 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				6B2F90E46EDA98C165F6F763 /* Components */,
+				B68B121AAD17F552A843D344 /* ViewModels */,
+				FB6A3B986F805ABD69A1CE43 /* Views */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		A1A6B05FEFFC44B49F573F9B /* Features */ = {
+			isa = PBXGroup;
+			children = (
+				3F0FA47DE12760C99F6BCE6E /* Approval */,
+				5DD9A7473C765C12598D89BF /* Auth */,
+				E5E0D47BDDA14AD48FAD2CF2 /* Chat */,
+				D208031B6046B236CA9BC774 /* FileSharing */,
+				49D8925FD3E04F5821CA1D8D /* Home */,
+				9C3924380667E803AC24E6E8 /* Notifications */,
+				2874D38FE863E4B978F51169 /* Progress */,
+				8218A28AA23789A29B4070CE /* Project */,
+				9D5C6E6476A38E0C37F672A0 /* ScreenshotViewer */,
+				D9FA893A4A42D3F507253C17 /* Settings */,
+				E37A3FF3E4B1C68B85657016 /* VoiceInput */,
+				2F93C278672D7B028DD3B802 /* VoiceOutput */,
+			);
+			path = Features;
+			sourceTree = "<group>";
+		};
+		A1A724B92A4546B44C672126 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				0F9B3C372438247C548DEEC4 /* FileTestFactory.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		A4CDA83603ED1A8D93F349F9 /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				2100910A3D82B228DF6E889C /* StartVoiceRecordingUseCase.swift */,
+				C37A177D1938F74CDAA6D30C /* StopVoiceRecordingUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		A56EC8A02A663464548474EE /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				E123D689391F5EDCB9E1D919 /* ApprovalCardViewModelTests.swift */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		A5CAED907E08EC8503FBE1BA /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				D101B741ABFC1B7514DADBFE /* RFLanguageSelector.swift */,
+				C400ADD3AA001DA1105EBDDC /* RFTranscriptionOverlay.swift */,
+				D026E5183E0472546C7337C1 /* RFVoiceInputButton.swift */,
+				D0FDCB895C361FB669FAEE86 /* RFWaveformView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		A5D4C26FD6D61A2A350E8AFD /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				9FA104FEB0FD2EFD04B0CD61 /* Project.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		A6ADA4AAE554E81E6EDC3135 /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+				6D2E715CC7C6C779BB201966 /* ProgressMapper.swift */,
+			);
+			path = Mappers;
+			sourceTree = "<group>";
+		};
+		A6F625DE3542D7F999D4D5FA /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				34B76F5DDDC98EB6CDC179A9 /* DTOs */,
+				CAB83AD537A24990345A5018 /* Mappers */,
+				46D7DC1A5B867D6929829BC4 /* Repositories */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		A753CA8FFC709889B01EB9F0 /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+				366FF9F51004CD680DDF3CB2 /* NotificationMapper.swift */,
+			);
+			path = Mappers;
+			sourceTree = "<group>";
+		};
+		A841F9976BE2067DE65BD708 /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				194298D1B4B047D4196B5BC9 /* LoadScreenshotUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		AAB9E670EE53446ED80B35E3 /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				9EFE790132F623C0887C8BA5 /* LoadChatHistoryUseCase.swift */,
+				53122A6023B9C8527386D149 /* SendMessageUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		AAC4C5EFEEA19F65AF44A7A8 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				8335D87CD04F6914A8C6A8D1 /* SettingsView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		AB39BCD6D3A77861FB627A10 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				0BA37EB0CDF96E19A3DECC86 /* MockVoiceInputRepository.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		AB738373DA1F70E1CC51B98D /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				2C7257C2689A8E6A9F2385F6 /* AuthDTOs.swift */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		ACDD2BCE3ECAF53CC2AE93E3 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				C1B19EC9D9485E170060FE3F /* MockFileRepository.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		AF8A351F986473A0073C0D18 /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				32C50619DD04EF18D55CB97E /* RFSpacingTests.swift */,
+				29D3E3C09D1313A1910F194C /* RFTypographyTests.swift */,
+			);
+			path = Theme;
+			sourceTree = "<group>";
+		};
+		B05CA43F814662E55E207FD7 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				DA3D573C4FCB2B3CA5F38D93 /* ApprovalTestFactory.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		B30927AC3DD63B19D7206057 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				5E2DD85745706E339B58077A /* NotificationRepositoryProtocol.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		B5CB1382EF424D06DDEBE8D3 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				892254DE431505E6DF6AFEC3 /* RFPlaybackButton.swift */,
+				AD54C402190CF29D5AADD728 /* RFPlaybackProgressBar.swift */,
+				0624F3BB62C9C6181240329F /* RFSpeedControl.swift */,
+				03BAA8A08BABA9E6CCBB3CC5 /* RFVoiceSelector.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		B68B121AAD17F552A843D344 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				39B7392B3C3929C15B48D2CD /* NotificationSettingsViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		B6A13CA167738E44AE50FCB7 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				055E28D940E02DA439783890 /* Components */,
+				55C3FB090184336CC0CA4EE2 /* ViewModels */,
+				42DF21E27F158F4D8582C424 /* Views */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		B6BC90DBA6BE4F7CD08D6646 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				A5D4C26FD6D61A2A350E8AFD /* Models */,
+				E8B608932CC9671215585A0E /* Repositories */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		B71946E9C5270228B87FF414 /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				FD5A0CEEA28B2E01F3408A9A /* ChatAttachmentDTO.swift */,
+				C93E0C5E2CB85ADDF4C6157F /* ChatMessageDTO.swift */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		B8271DA014C9CEE0F6F1D468 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				BFDAA9F81B14E7D8A13DEC7E /* MockApprovalRepository.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		BA2A91070A4308BCC44C1053 /* VoiceInput */ = {
+			isa = PBXGroup;
+			children = (
+				DA09CD4E1063838B75B77104 /* Data */,
+				BEF1537E2519F87B79ACA09A /* Domain */,
+				D54C9BA898D34EA1A5BB1D1F /* Presentation */,
+			);
+			path = VoiceInput;
+			sourceTree = "<group>";
+		};
+		BA7EAFCA5E157FBEA23C283A /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				F91B37544AF71EF06D1F7BC4 /* NotificationCategory.swift */,
+				910E048030BCE704D1ACC9F8 /* PushNotification.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		BB912EB55B8BF50EE07DA94D /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				E692CD287F1339A656B9D07D /* Components */,
+				011C82C62581BEC3BE838891 /* ViewModels */,
+				AAC4C5EFEEA19F65AF44A7A8 /* Views */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		BBDE6C74FF67C05B890B003E /* Progress */ = {
+			isa = PBXGroup;
+			children = (
+				6804DCF41ED03AD6C80FAA2A /* Data */,
+				D27695656CEEE2F1F3E090BA /* Domain */,
+				75E0C4D168863ADB21A4F0A0 /* Presentation */,
+			);
+			path = Progress;
+			sourceTree = "<group>";
+		};
+		BC79E32E698EC0413104F0D7 /* DesignSystem */ = {
+			isa = PBXGroup;
+			children = (
+				1D96F6CAB7F77B538976FA99 /* Components */,
+				3A77F862DE4FA2A7B45B20CC /* Theme */,
+			);
+			path = DesignSystem;
+			sourceTree = "<group>";
+		};
+		BDF5EC760F14D54FC144458F /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				919770F140B17FDB577BAC91 /* AppSettingsModelTests.swift */,
+				17C0B926BBA0C8F6EBBAA19C /* LoadSettingsUseCaseTests.swift */,
+				A961F116D1108B39252EE3C1 /* SaveSettingsUseCaseTests.swift */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		BED0A96AFC6C569770CA9F6F /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				9DDDFA07B5EA521B249A6404 /* AuthInterceptorTests.swift */,
+				2414963E26EADDBD66E7BCF7 /* AuthManagerTests.swift */,
+				296C5F89DB28B601903F738E /* BiometricAuthManagerTests.swift */,
+				0311D62510D1BCEA61F04553 /* KeychainHelperTests.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		BEF1537E2519F87B79ACA09A /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				FE8F047A4CB50CAFA1344C3C /* Models */,
+				55AC8304EDC7E348A0DE8270 /* Repositories */,
+				A4CDA83603ED1A8D93F349F9 /* UseCases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		BF2C977A8D58E6C89567562F /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				073B5D01B9C1C155E7F5A50C /* NotificationRouter.swift */,
+				71C93280E1D8CE2C3ED37AB6 /* PushNotificationManager.swift */,
+			);
+			path = Notifications;
+			sourceTree = "<group>";
+		};
+		BF2FE0A126F4B98B04E6406C /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				68EDD58FB04BAB8CFFBF18E2 /* ScreenshotTestFactory.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		BF6BA117E8E963163AED3A37 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				DFA6E443317BC57250C82113 /* ProgressViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		C04F67BE5D05920BDFD0CA6C /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				9FC63BF2A36DEB6F8E414E00 /* ObserveProgressUseCaseTests.swift */,
+				F5224B55A7BB421788157E25 /* ProgressModelTests.swift */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		C0D37D5BE3249E2E9E8CC4A3 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				F2F36517B94A8021E276737B /* TTSMapperTests.swift */,
+				5CC24C8A34CD821C9003485F /* TTSRequestDTOTests.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		C146D6C56124A8C3A2206A9C /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				7349869B86F354624F54074F /* ScreenshotRepositoryImpl.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		C1C761F83B1C8F02C519D859 /* Project */ = {
+			isa = PBXGroup;
+			children = (
+				E17CE237D4C335FC4529CA7B /* Data */,
+				CBD54391BE4B1DF1968D7A7B /* Domain */,
+				2F00290C788FD1FDC83FF939 /* Presentation */,
+			);
+			path = Project;
+			sourceTree = "<group>";
+		};
+		C276EA0275D6BEE9A683C83E /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				BFAFAD24416A098AFFD9D60C /* AuthModels.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		C4507A0FE0601CD7FB73158F /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				27C2C8D35DF1863D6D75A0CB /* Models */,
+				05AB44882E53DCF61F58FA77 /* Repositories */,
+				A841F9976BE2067DE65BD708 /* UseCases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		C55D7F60C0C7995ABA17C11E /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				65A7CF6BE6C6D35BDCF28F53 /* ChatViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		C5870DD825D1A969D44FFA8B /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				03AD4E549ED602E49AA76507 /* SynthesizeSpeechUseCaseTests.swift */,
+				1776AD17EDD35DB4E0121C58 /* TTSAudioResultTests.swift */,
+				89E22F1EE77DE2427DE1E085 /* TTSRequestTests.swift */,
+				FBFE526FB9C651EB7DCE792E /* TTSVoiceTests.swift */,
+				3198A348F640159070EE2331 /* VoiceOutputStateTests.swift */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		C9C8FCA6003388098A42F704 /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				0DA1AB7899F9DFDFABB9E7A4 /* DeepgramMessageDTO.swift */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		CAB83AD537A24990345A5018 /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+				6BA56FA16D9B33499BB1DB2B /* FileMapper.swift */,
+			);
+			path = Mappers;
+			sourceTree = "<group>";
+		};
+		CB7A3F66AE349BEBC81EEF0D /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				E4D0B1722F9261441B62830E /* AppLogger.swift */,
+			);
+			path = Logging;
+			sourceTree = "<group>";
+		};
+		CBD54391BE4B1DF1968D7A7B /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				60A49E2DB4FA240E7690B242 /* Repositories */,
+				3C40B159CCF466173FD5ECDF /* UseCases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		CCA3DA17B8A0C50ECF6BB3B4 = {
+			isa = PBXGroup;
+			children = (
+				188C2CD1E0213D9083BBABDC /* RafRaf */,
+				56C4772545FFC1AE452C623A /* RafRafTests */,
+				0569E193F47F2E1CEB1EC457 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		CCAF4A603061081A9FE38741 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				D3B7498BA91A02D08B6CA590 /* ApprovalRepositoryProtocol.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		CCE80C5AB1369E5FD2D07632 /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				C7F6D7D2C0636983F1E7E31A /* ProjectStatusDTO.swift */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		CD7F1701EF1339281E066E55 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				9DD0F371A5AE58F7716D94C5 /* ScreenshotViewerView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		CEB6497C30546F2CFB396711 /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+				B3D45E1077BE0DB5D8B8471A /* TTSMapper.swift */,
+			);
+			path = Mappers;
+			sourceTree = "<group>";
+		};
+		CFD22DA06A96016F7C96E4DE /* Approval */ = {
+			isa = PBXGroup;
+			children = (
+				79D234B772B3550DB7089BC6 /* Data */,
+				37197300D6C9A0509E567808 /* Domain */,
+				9F0D61BADBB49F4A3C4FE540 /* Presentation */,
+			);
+			path = Approval;
+			sourceTree = "<group>";
+		};
+		D14F9A966DB22E931488DEE9 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				98F2F4EA4F9814837DF581E7 /* Data */,
+				B6BC90DBA6BE4F7CD08D6646 /* Domain */,
+				20E314299F9CE126FBE89C2E /* Presentation */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		D208031B6046B236CA9BC774 /* FileSharing */ = {
+			isa = PBXGroup;
+			children = (
+				654C71B37464BF83B3796651 /* Data */,
+				53543F25197AF8EA472B4094 /* Domain */,
+				A1A724B92A4546B44C672126 /* Helpers */,
+				ACDD2BCE3ECAF53CC2AE93E3 /* Mocks */,
+				EE928EAF9F00D5D629B77CCD /* Presentation */,
+			);
+			path = FileSharing;
+			sourceTree = "<group>";
+		};
+		D27695656CEEE2F1F3E090BA /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				7DDF8E9B71C8CD499B5CD809 /* Models */,
+				8677DAF1E168E22582BBC410 /* Repositories */,
+				8B9F452494BE50F8C5409E82 /* UseCases */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		D3211E0CD8113354C4F74A5E /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				F8C9DD548ED813FFD84304A3 /* RFScreenshotFullScreenView.swift */,
+				03A5DF15DB7979A572992F5B /* RFScreenshotViewer.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		D3E3DA3BC38545FDC79454F0 /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+				F7561424D168B690C0D88BA1 /* ChatMessageMapper.swift */,
+			);
+			path = Mappers;
+			sourceTree = "<group>";
+		};
+		D54C9BA898D34EA1A5BB1D1F /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				A5CAED907E08EC8503FBE1BA /* Components */,
+				81CA7D86D04DDD264AE0C7AC /* ViewModels */,
+				0EBB6EB2E19C22BE47971CA2 /* Views */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		D63817B372E2117ECFD9F8B8 /* Chat */ = {
+			isa = PBXGroup;
+			children = (
+				F888B785B2F2F0EA8512845D /* Data */,
+				73FBDA34D6D6C8F61A2349CB /* Domain */,
+				92A99870133EB07AC167ACC8 /* Presentation */,
+			);
+			path = Chat;
+			sourceTree = "<group>";
+		};
+		D6E529154A3F1E39AE3D1E9B /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				E6124D6E1DECAB58D50AE8B0 /* View+Extensions.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		D8D4F481C0304CE47F7679B5 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				E1A233B6173D693D3E16616C /* DeepgramMessageDTOTests.swift */,
+				245EE9BB70C1492C10B50AC4 /* TranscriptionMapperTests.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		D9FA893A4A42D3F507253C17 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				64AE3B2E7F1F843FB195A526 /* Data */,
+				BDF5EC760F14D54FC144458F /* Domain */,
+				2270A56D5AA4C2E3A045F6AE /* Helpers */,
+				6784BE2CDCB1872419F659DA /* Mocks */,
+				77C1049FB4E371092B257E83 /* Presentation */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		DA09CD4E1063838B75B77104 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				C9C8FCA6003388098A42F704 /* DTOs */,
+				E3182E15FBFDD77E273039E2 /* Mappers */,
+				A06E724D119E594A88E15630 /* Repositories */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		DB8C94EC5834DEEF693C7349 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				25D6A0A56D2F70FA7FCDF5EE /* DTOs */,
+				974D0DBB491F40017800F71A /* Mappers */,
+				12EA9B89AE81E62A5BD572B4 /* Repositories */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		DCFAD1D7C273AFA57C032AA9 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				CE63BB82B0AF956CDD1A5B38 /* ProjectDetailViewModel.swift */,
+				50917FA7893DF99B7E119E32 /* ProjectListViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		DEEFC5BD00D95B7499D508B1 /* DesignSystem */ = {
+			isa = PBXGroup;
+			children = (
+				002A0A65959CFD8B19386432 /* Components */,
+				AF8A351F986473A0073C0D18 /* Theme */,
+			);
+			path = DesignSystem;
+			sourceTree = "<group>";
+		};
+		E14C7822C08AEEEF0266CF92 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				B5CB1382EF424D06DDEBE8D3 /* Components */,
+				21D47D44CC63EE70D29B81BA /* ViewModels */,
+				30663F21EE8552A3A8BF582A /* Views */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		E17CE237D4C335FC4529CA7B /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				CCE80C5AB1369E5FD2D07632 /* DTOs */,
+				E7E383FD108741F639BCFB7B /* Mappers */,
+				2E124DE23AF5BE1C2038BF04 /* Repositories */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		E1A61BB04368FE734AA4F7B3 /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+				895687B790F7F39124904D09 /* ProjectMapper.swift */,
+			);
+			path = Mappers;
+			sourceTree = "<group>";
+		};
+		E3182E15FBFDD77E273039E2 /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+				6806D0CBEB4C320AB5122A0A /* TranscriptionMapper.swift */,
+			);
+			path = Mappers;
+			sourceTree = "<group>";
+		};
+		E326AECC462A621C4D8EF88A /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				CE91FB0E476FF189A678A9DC /* DeviceTokenDTO.swift */,
+				B5F5D229C933E99E99E9C199 /* NotificationPayloadDTO.swift */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		E37A3FF3E4B1C68B85657016 /* VoiceInput */ = {
+			isa = PBXGroup;
+			children = (
+				D8D4F481C0304CE47F7679B5 /* Data */,
+				4A92EF35966FCBA8EDD0C9C4 /* Domain */,
+				FEB2F2780009A1D7FAB59740 /* Helpers */,
+				AB39BCD6D3A77861FB627A10 /* Mocks */,
+				227C037F767A5A17E3C2C934 /* Presentation */,
+			);
+			path = VoiceInput;
+			sourceTree = "<group>";
+		};
+		E5E0D47BDDA14AD48FAD2CF2 /* Chat */ = {
+			isa = PBXGroup;
+			children = (
+				58BF24274BDDFD0EE058DBAC /* Data */,
+				5561F4DEE7688E31841105C0 /* Domain */,
+				EB4B2E6D582F056718520E8D /* Mocks */,
+				2AB3DEF8486E7338DC7A094D /* Presentation */,
+			);
+			path = Chat;
+			sourceTree = "<group>";
+		};
+		E692CD287F1339A656B9D07D /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				629C0C741A2EA1DCC248E89B /* RFSettingsRow.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		E6EB440AB200FE75366DB3B5 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				F41AA8948BA168061C1A7693 /* ProgressRepositoryImpl.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		E7E383FD108741F639BCFB7B /* Mappers */ = {
+			isa = PBXGroup;
+			children = (
+				4959793D375BCA1E8998696B /* ProjectStatusMapper.swift */,
+			);
+			path = Mappers;
+			sourceTree = "<group>";
+		};
+		E8B608932CC9671215585A0E /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				5C1E87C612CE695839F215FB /* ProjectRepositoryProtocol.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		E8E3AC9F24054511B2492F3E /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				F2198BE7D92A94C10AAE85AD /* ProgressMapperTests.swift */,
+				108EEC88530B42D3365B0CF7 /* ProgressRepositoryImplTests.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		EB4B2E6D582F056718520E8D /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				D5C19344181D70DA7F175D9E /* MockChatRepository.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		ECB39E431C8078170FC1EF7C /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				5FA90491980773FB61DE6751 /* RFBiometricButton.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		EE928EAF9F00D5D629B77CCD /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				2B3A1719F6E181EFA9D1B5DE /* FilePickerViewModelTests.swift */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		F888B785B2F2F0EA8512845D /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				B71946E9C5270228B87FF414 /* DTOs */,
+				D3E3DA3BC38545FDC79454F0 /* Mappers */,
+				3285F82E0B01932D835642AE /* Repositories */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		FA1C8D64AB66249AE95FE258 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				E326AECC462A621C4D8EF88A /* DTOs */,
+				A753CA8FFC709889B01EB9F0 /* Mappers */,
+				FD35C48F71471DB6104C65EF /* Repositories */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		FB2779B4FCE83EBBA2D09B1F /* FileSharing */ = {
+			isa = PBXGroup;
+			children = (
+				A6F625DE3542D7F999D4D5FA /* Data */,
+				01D90EE7F61EE7F50E3BFB9C /* Domain */,
+				B6A13CA167738E44AE50FCB7 /* Presentation */,
+			);
+			path = FileSharing;
+			sourceTree = "<group>";
+		};
+		FB6A3B986F805ABD69A1CE43 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				D338A67C42C34EA7A5F34CB9 /* NotificationSettingsView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		FB875E802416E149FADB9DE3 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				6B034A26D2C78F515EE7DC5A /* ApprovalModelTests.swift */,
+				63C25805409AC677AE951BA8 /* SubmitApprovalDecisionUseCaseTests.swift */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		FBA3FCBCCE3B469668C0CC82 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				861FC01286FCBF2C7798215C /* DTOs */,
+				CEB6497C30546F2CFB396711 /* Mappers */,
+				4E2AF205AF92EE8F566AA731 /* Repositories */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		FCC9D01BD2C91A6FB0C2EC59 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				3D9E456B2FE6369859C095F9 /* MockProjectRepository.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		FD35C48F71471DB6104C65EF /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				89A7251A9986AF590322D9B1 /* NotificationRepositoryImpl.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		FD5C5788FDB49E89C5299E71 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				DCE433D8C6C908371422E9E3 /* ProjectDetailView.swift */,
+				1C56E0953632D7176D2CE8C1 /* ProjectListView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		FE8F047A4CB50CAFA1344C3C /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				4D8160CA803E7D4E3A1214AF /* TranscriptionResult.swift */,
+				EE99A9CC802FA53865A170A8 /* VoiceInputState.swift */,
+				DD43B55D9F303CA181C0D313 /* VoiceLanguage.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		FEB2F2780009A1D7FAB59740 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				E57A611E9759F629A8F4C5ED /* VoiceInputTestFactory.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		2CC52146BD6CF99A70B8CFA3 /* RafRaf */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F301B6F7C129BA404FFE08C0 /* Build configuration list for PBXNativeTarget "RafRaf" */;
+			buildPhases = (
+				BA5DED682C8B5DF32E6135F3 /* Sources */,
+				294563B3FAF7BDC7BC596440 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RafRaf;
+			packageProductDependencies = (
+				ECB3212567B4D6E2AE1748D8 /* Factory */,
+				6E10A0D15B0B7D188A64F34E /* Nuke */,
+				E1E2A2A56BA5D07346F09E34 /* NukeUI */,
+			);
+			productName = RafRaf;
+			productReference = 91541D471DBA109AA6FADD7B /* RafRaf.app */;
+			productType = "com.apple.product-type.application";
+		};
+		4CEBB5AE9DA5DDB2803DA0D0 /* RafRafTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CE4957F9EEAEF8B3536AB708 /* Build configuration list for PBXNativeTarget "RafRafTests" */;
+			buildPhases = (
+				D6D8C75D6C106B50D424A262 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5C2EF136E49BC77606B66768 /* PBXTargetDependency */,
+			);
+			name = RafRafTests;
+			packageProductDependencies = (
+			);
+			productName = RafRafTests;
+			productReference = 429F7CAB9685E8ABE03DB4E0 /* RafRafTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		07E1E16FD89DE3C0B3FD36FA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					2CC52146BD6CF99A70B8CFA3 = {
+						DevelopmentTeam = "";
+						ProvisioningStyle = Automatic;
+					};
+					4CEBB5AE9DA5DDB2803DA0D0 = {
+						DevelopmentTeam = "";
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 7982111198C1AC0AFA36690A /* Build configuration list for PBXProject "RafRaf" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = CCA3DA17B8A0C50ECF6BB3B4;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				9661151B4FBCF41DF1F308C3 /* XCRemoteSwiftPackageReference "Factory" */,
+				235A2FDE642AE94989E33D25 /* XCRemoteSwiftPackageReference "Nuke" */,
+			);
+			preferredProjectObjectVersion = 77;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2CC52146BD6CF99A70B8CFA3 /* RafRaf */,
+				4CEBB5AE9DA5DDB2803DA0D0 /* RafRafTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BA5DED682C8B5DF32E6135F3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A98693C70B9BBE3979DA0685 /* AppContainer.swift in Sources */,
+				D603913E1499B617128063BC /* AppDelegate.swift in Sources */,
+				9CC04BC3F7D82C475AD74B15 /* AppEnvironment.swift in Sources */,
+				2F3AF5D31BC16ADB2632C01E /* AppLogger.swift in Sources */,
+				43AD14D68F6F2B2A3CBA4503 /* AppSettings.swift in Sources */,
+				CA89DBA76660BDE736B6CE49 /* ApprovalCardViewModel.swift in Sources */,
+				ADFE3CD8098A6AD2B1107FA4 /* ApprovalMapper.swift in Sources */,
+				713A4881DF334F581E84388C /* ApprovalOption.swift in Sources */,
+				324142A3F5FBEDC5DB58AE01 /* ApprovalQuestion.swift in Sources */,
+				170305E3526BE2CD9BE0A789 /* ApprovalQuestionDTO.swift in Sources */,
+				ADBD7494FF02D52E57036464 /* ApprovalRepositoryImpl.swift in Sources */,
+				48D6EDC37627B786BA0C66B6 /* ApprovalRepositoryProtocol.swift in Sources */,
+				35A9D0F7A2B7F2F954DDB024 /* ApprovalResponseDTO.swift in Sources */,
+				948990E90BB339DCB927D712 /* AuthDTOs.swift in Sources */,
+				8ABCE16459E196294FBD136E /* AuthInterceptor.swift in Sources */,
+				76C10079D554065D4A3DB548 /* AuthManager.swift in Sources */,
+				F29DEC7E12B40AE5E40A9260 /* AuthMapper.swift in Sources */,
+				4B9D07E2290FA0285043EB11 /* AuthModels.swift in Sources */,
+				EC27E0DDC9D27BB3247B76AF /* AuthRepository.swift in Sources */,
+				6E21CB6800808FF30162E496 /* AuthRepositoryImpl.swift in Sources */,
+				AECAC1C68D46FD67182E0DE8 /* AuthViewModel.swift in Sources */,
+				99FACAF4013440182B994660 /* BiometricAuthManager.swift in Sources */,
+				44864A3B0FFC3FB5DE6A680A /* BiometricLoginUseCase.swift in Sources */,
+				B794433447C5FC8E6F3EF24A /* ChatAttachment.swift in Sources */,
+				1CC9608784807ECCA5328745 /* ChatAttachmentDTO.swift in Sources */,
+				9EFF71224159A65F07F50A5F /* ChatMessage.swift in Sources */,
+				C8FEF24EC70EBFB3362DCDAF /* ChatMessageDTO.swift in Sources */,
+				4411C8B0224B50F3D8722FB8 /* ChatMessageMapper.swift in Sources */,
+				A4E21319115E48A9BACD194E /* ChatRepositoryImpl.swift in Sources */,
+				6B80EC328FFA12586B465DD0 /* ChatRepositoryProtocol.swift in Sources */,
+				00E71759402C5B52C67BE896 /* ChatView.swift in Sources */,
+				09FD1381D6990FAC0EFC2906 /* ChatViewModel.swift in Sources */,
+				E4D20264B06E3BA886B7BE9D /* ContentView.swift in Sources */,
+				08A0A6FEFD4129A9250D7D4F /* DeepgramMessageDTO.swift in Sources */,
+				55FFE6B80055DD880C80680D /* DeviceTokenDTO.swift in Sources */,
+				32E0335FCFB1EE2A2B21FA7A /* DownloadFileUseCase.swift in Sources */,
+				8C74F34C7922DDAA72AA59D9 /* FileDownloadResponseDTO.swift in Sources */,
+				9DBD440AD8BA9DC30142CB52 /* FileMapper.swift in Sources */,
+				3D8C1E1CB0832C4FDA0E5639 /* FileMetadataDTO.swift in Sources */,
+				74DA8BF1ED8BBBAD6E720E0D /* FilePickerViewModel.swift in Sources */,
+				D301FE4FCFA755A12544C3B7 /* FileRepositoryImpl.swift in Sources */,
+				B58DB0C21072C716126D6BFF /* FileRepositoryProtocol.swift in Sources */,
+				5A603B913CF17307F80FEA25 /* FileUploadProgress.swift in Sources */,
+				B196AAB927B6E4410EC2F59E /* FileUploadRequestDTO.swift in Sources */,
+				9E4F23134A68C9CC84A394B1 /* FileUploadResponseDTO.swift in Sources */,
+				603B0EFE112BCD23843429BE /* GetProjectDetailUseCase.swift in Sources */,
+				2DA861BF0D903CCBEF2917A8 /* GetProjectsUseCase.swift in Sources */,
+				0C016A0096A0AE5F1DD742AE /* HandleNotificationUseCase.swift in Sources */,
+				D2378F47B5C1F00A35902C2F /* HomeView.swift in Sources */,
+				5ECD4C9BD68F9C09D20F5E20 /* HomeViewModel.swift in Sources */,
+				23DDF59C55AA208C878A40FC /* KeychainHelper.swift in Sources */,
+				70FBD109CFBA054CAD3A8FCF /* LoadChatHistoryUseCase.swift in Sources */,
+				BEE32543ECCE5092CA35F951 /* LoadScreenshotUseCase.swift in Sources */,
+				E5ED3D543074B50FD6ED7263 /* LoadSettingsUseCase.swift in Sources */,
+				FC196297F8982111BF52B197 /* LoginUseCase.swift in Sources */,
+				CA7070818E078B512574EEC4 /* LogoutUseCase.swift in Sources */,
+				12AA105F2ED968F9FB79B868 /* NetworkClient.swift in Sources */,
+				D2EE4339B1BF3012C62EB2E4 /* NotificationCategory.swift in Sources */,
+				A4E6BF9260001ED1544A8B72 /* NotificationMapper.swift in Sources */,
+				BD3EAE76FF7B0B49845C34EE /* NotificationPayloadDTO.swift in Sources */,
+				69BB92ECCA2D93A144EA055A /* NotificationRepositoryImpl.swift in Sources */,
+				132C7631415CBB0529872367 /* NotificationRepositoryProtocol.swift in Sources */,
+				2C934D278CD3A23533150EBD /* NotificationRouter.swift in Sources */,
+				4FA7F667D0D7818078A279CD /* NotificationSettingsView.swift in Sources */,
+				84639ABFFAB351AF7B72C150 /* NotificationSettingsViewModel.swift in Sources */,
+				0B3BA88DE6894D76EA3165AF /* ObserveProgressUseCase.swift in Sources */,
+				FF2F90675AC4434D50B7CC14 /* ProgressEventDTO.swift in Sources */,
+				5202090B497489C821305526 /* ProgressMapper.swift in Sources */,
+				7A9E864C63FA0554E738EFB3 /* ProgressRepositoryImpl.swift in Sources */,
+				E2C742F6DA327081E0D2B7A9 /* ProgressRepositoryProtocol.swift in Sources */,
+				2082D7617DDDD3948E276962 /* ProgressState.swift in Sources */,
+				DA979C1B30AEA06D8EC2C330 /* ProgressStep.swift in Sources */,
+				2C86C4C06F663280FAD125AB /* ProgressView.swift in Sources */,
+				3EC7B34BB24C56D3DD16B465 /* ProgressViewModel.swift in Sources */,
+				22A5ABD1132ACBFA8D792AB9 /* Project.swift in Sources */,
+				0FB1D09FEFE6438C1855DAEA /* ProjectDTO.swift in Sources */,
+				4F6B9B9399A69F6315EB7431 /* ProjectDetailView.swift in Sources */,
+				3A38E7A682E185774E6519D7 /* ProjectDetailViewModel.swift in Sources */,
+				78C20ABE8AC8A34BAF0F0952 /* ProjectListView.swift in Sources */,
+				6F623B970925898AF1BA733E /* ProjectListViewModel.swift in Sources */,
+				FC7306E255FD9A39D77FFB07 /* ProjectMapper.swift in Sources */,
+				D3587F0CD1FAE5126EE9387F /* ProjectRepositoryImpl.swift in Sources */,
+				6EB280CD6A954C9D2898A59E /* ProjectRepositoryProtocol.swift in Sources */,
+				3BA9D7B80DD0640E82CCAF06 /* ProjectStatusDTO.swift in Sources */,
+				9C95BDEE6FE4779CB035A034 /* ProjectStatusMapper.swift in Sources */,
+				5EF10B33094C6B775B55F8FF /* ProjectStatusRepository.swift in Sources */,
+				821F0574AAC95057BEE9DC1F /* PushNotification.swift in Sources */,
+				0883540B6F520BF888F35BCC /* PushNotificationManager.swift in Sources */,
+				2F9CFBF1478CCE71325589B6 /* RFApprovalCard.swift in Sources */,
+				374B87F946F37A59FC330A8C /* RFApprovalOptionButton.swift in Sources */,
+				09031E9D7E761B47D391B82A /* RFAudioSessionManager.swift in Sources */,
+				2D63E129E0C52CE9E2F2DC3F /* RFAvatar.swift in Sources */,
+				53CA3BCB0C9149577DF1FB5E /* RFBiometricButton.swift in Sources */,
+				3ABA5BF8EB9D9235CA41BD2D /* RFButton.swift in Sources */,
+				BF1FDFE6A2A9D502C7B02365 /* RFCard.swift in Sources */,
+				42B5E3AB236F1D7B479D4AE6 /* RFChatInput.swift in Sources */,
+				A32481051F472709B19F6D75 /* RFCodeBlock.swift in Sources */,
+				EDFAA96C8F5C83B957E1DC86 /* RFColors.swift in Sources */,
+				022E4B32DEA2F3ED740BF4C0 /* RFCountdownTimer.swift in Sources */,
+				1A3BFE87C89518227FA52615 /* RFEmptyStateView.swift in Sources */,
+				455C6DB50B6837B34717A760 /* RFErrorView.swift in Sources */,
+				97BF50FCDCBAC8DD8B199BDC /* RFFileAttachmentCard.swift in Sources */,
+				770A580D5151BCA0E6099978 /* RFFilePickerView.swift in Sources */,
+				25523C8B1BFFE6EF66C8222D /* RFFilePreviewView.swift in Sources */,
+				53CD1B6EF64AEBFFE77C7C91 /* RFImageMessageView.swift in Sources */,
+				E37154C32EDE14FFC8288D16 /* RFLanguageSelector.swift in Sources */,
+				9FCD8CB4BFE8F40FC4223322 /* RFLoadingView.swift in Sources */,
+				1BDC516014CF53D3C0701DFF /* RFLoginView.swift in Sources */,
+				D1D8D7FD889AF9F9988C1B2D /* RFMessageBubble.swift in Sources */,
+				51E7A1C0B529AD821DBF4BDB /* RFNotificationBanner.swift in Sources */,
+				9E2FD1989B9E6AAA52B2FBA2 /* RFPlaybackButton.swift in Sources */,
+				DFAA7555B73340B4FEE64E1A /* RFPlaybackProgressBar.swift in Sources */,
+				EFCD551C0C3025172F7FBA61 /* RFProgressIndicator.swift in Sources */,
+				483B69F197C7E5E3605B0CE6 /* RFProjectCard.swift in Sources */,
+				A251112BB37D265712C60859 /* RFProjectStatusBadge.swift in Sources */,
+				F01B19A772173B4171C6F451 /* RFRegisterView.swift in Sources */,
+				FDD1A5FB33590ABD19B5939C /* RFScreenshotFullScreenView.swift in Sources */,
+				9E438DF05967EBE422615DA5 /* RFScreenshotViewer.swift in Sources */,
+				01719DC9951AE7891BDD95E0 /* RFSettingsRow.swift in Sources */,
+				2DD8447B16F1E049005D1493 /* RFSpacing.swift in Sources */,
+				6126E7278D2FF1AE83AA955E /* RFSpeechRecognizer.swift in Sources */,
+				E4B632FB67D23B0519699CB1 /* RFSpeedControl.swift in Sources */,
+				4340763335A59253756E7E95 /* RFStepProgressView.swift in Sources */,
+				82775AD57DA8B1B053EBD608 /* RFText.swift in Sources */,
+				6DE6DB6F070257976E7861F6 /* RFTextField.swift in Sources */,
+				494E791ED2621314109FC9AA /* RFToolStatusView.swift in Sources */,
+				466CA6F0C0CD819EFFE6D1B7 /* RFTranscriptionOverlay.swift in Sources */,
+				CE6768C80CB433F3BBC46ED5 /* RFTypingIndicator.swift in Sources */,
+				AE78026CAD68EE7743A9CF0B /* RFTypography.swift in Sources */,
+				5293CB1747FECB9D94975F73 /* RFUploadProgressView.swift in Sources */,
+				8323362B6FCD7F8A0594D05F /* RFVoiceInputButton.swift in Sources */,
+				7649EBAD8B21A59B66167260 /* RFVoiceInputView.swift in Sources */,
+				C8A5112302BF7D39C6D00224 /* RFVoiceOutputView.swift in Sources */,
+				20E1E60883F05FDD047D6558 /* RFVoiceSelector.swift in Sources */,
+				A21B88A6402FDD2B53F42D7F /* RFWaveformView.swift in Sources */,
+				8731A1F3065CA8D887333C03 /* RafRafApp.swift in Sources */,
+				8631DD138898851D7B1EC5B1 /* RefreshTokenUseCase.swift in Sources */,
+				180CE160ABC188916E202F40 /* RegisterDeviceTokenUseCase.swift in Sources */,
+				D20A4DF1D0A21ED665E7B805 /* SaveSettingsUseCase.swift in Sources */,
+				212C0308EE8AEA87A1C5B4B0 /* Screenshot.swift in Sources */,
+				1F6B0659DFC3BF6BF7FA3D8A /* ScreenshotDTO.swift in Sources */,
+				CC3D54FE8D12D799F04E419B /* ScreenshotMapper.swift in Sources */,
+				EAC285BFE9399C9A34318A47 /* ScreenshotRepositoryImpl.swift in Sources */,
+				0DAD8D681D8992E3C0C0A6B6 /* ScreenshotRepositoryProtocol.swift in Sources */,
+				82DE6F3EE500AE3DFE1424FF /* ScreenshotViewerState.swift in Sources */,
+				995ABFE19327680CECAD261A /* ScreenshotViewerView.swift in Sources */,
+				39528FF437D4E8F29DE73A67 /* ScreenshotViewerViewModel.swift in Sources */,
+				F6714D7D1A45086156152B93 /* SendMessageUseCase.swift in Sources */,
+				5AFB5D44BF96A2FCCB667BE5 /* SettingsRepositoryImpl.swift in Sources */,
+				D730FC59FDFAC53D8CB78C9F /* SettingsRepositoryProtocol.swift in Sources */,
+				E7574480EB35E3895E822873 /* SettingsView.swift in Sources */,
+				32657889244D50961E14014B /* SettingsViewModel.swift in Sources */,
+				90C2F03F9FEDE9C4BC4C172C /* SharedFile.swift in Sources */,
+				FC870F57F8296F7A057C2D65 /* StartVoiceRecordingUseCase.swift in Sources */,
+				B8EAE6E70D928471851D99E4 /* StopPlaybackUseCase.swift in Sources */,
+				A540D1ACEA5D06D6C80C2F2A /* StopVoiceRecordingUseCase.swift in Sources */,
+				EECAA7A546A3DD77278EDB3F /* SubmitApprovalDecisionUseCase.swift in Sources */,
+				CFDFBE7A7B06A275C7F9761C /* SupportedFileType.swift in Sources */,
+				0CA7B086A2C39B8BD75EFC89 /* SynthesizeSpeechUseCase.swift in Sources */,
+				F02FDF797BF94067EDB7FD69 /* TTSAudioCache.swift in Sources */,
+				06008B1B10A0C4CEBF73A731 /* TTSAudioResult.swift in Sources */,
+				6C436C809B7C4728E22079FC /* TTSMapper.swift in Sources */,
+				96C1AE90CF7954ADE5C5BBC5 /* TTSRequest.swift in Sources */,
+				0C8730146DEE46F8798954CF /* TTSRequestDTO.swift in Sources */,
+				D67D1D8C54D4B04159DA28FE /* TTSVoice.swift in Sources */,
+				FAEEF0302FBB337424A8235A /* TranscriptionMapper.swift in Sources */,
+				ABE150397E1D4260350113E3 /* TranscriptionResult.swift in Sources */,
+				E6E3A88D075CF310736237A0 /* UploadFileUseCase.swift in Sources */,
+				09726529F6A1DE96A4264DF8 /* UserProfile.swift in Sources */,
+				EF5E63D4A4015423C2C4BA2F /* UserProfileDTO.swift in Sources */,
+				C042AD76CA2A2AD4F64FDC4F /* UserProfileMapper.swift in Sources */,
+				23195AD5A4759668886E49F0 /* UserRepositoryProtocol.swift in Sources */,
+				F451E7C0EC330B8B9B9069B1 /* View+Extensions.swift in Sources */,
+				0486617591AA9DC73CCD5E40 /* VoiceAudioPlayer.swift in Sources */,
+				C104AC6C23ADF7BA097935AE /* VoiceInputRepositoryImpl.swift in Sources */,
+				7E1A8555C25F0D9364C2B9E9 /* VoiceInputRepositoryProtocol.swift in Sources */,
+				71FF04CAA175B88FAE72AE79 /* VoiceInputState.swift in Sources */,
+				53EE8B12B3AAA5FE2E8FF3E8 /* VoiceInputViewModel.swift in Sources */,
+				E38F6D750F0992BD53A0C01C /* VoiceLanguage.swift in Sources */,
+				85F48831C05227A4125ECE17 /* VoiceOutputRepositoryImpl.swift in Sources */,
+				ECEAC4C72130EC02BAF267E9 /* VoiceOutputRepositoryProtocol.swift in Sources */,
+				BFD5AF56D7FC3C1C7D7A6DB8 /* VoiceOutputState.swift in Sources */,
+				720A276878F44B627F034860 /* VoiceOutputViewModel.swift in Sources */,
+				45601D37FEEA39D7808D30AA /* WebSocketClient.swift in Sources */,
+				4F786E4007A7463FF1224BC4 /* WebSocketConnectionManager.swift in Sources */,
+				5D6D478EB4B39272CAC3207C /* WebSocketMessage.swift in Sources */,
+				7F69C861FBECE104AB7AC76E /* WebSocketMessageRouter.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6D8C75D6C106B50D424A262 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				397062E55ADD9D6034FFAC6C /* AppSettingsModelTests.swift in Sources */,
+				35A0D790EAD344C13F946454 /* AppTabTests.swift in Sources */,
+				2F231408FDDB60ABCC215B2D /* ApprovalCardViewModelTests.swift in Sources */,
+				C04EECE10C7CB20D13384ACD /* ApprovalMapperTests.swift in Sources */,
+				941B0A53882A36B1ED352971 /* ApprovalModelTests.swift in Sources */,
+				03A0DAF73C6811B082C60CE9 /* ApprovalQuestionDTOTests.swift in Sources */,
+				5B6F7CE82B6EBDD641DAB5B6 /* ApprovalTestFactory.swift in Sources */,
+				A45276EAA22DCBACB3FB5896 /* AudioLevelTests.swift in Sources */,
+				683E92792EA4E9C10756A27B /* AuthInterceptorTests.swift in Sources */,
+				F25459C2C9FA9461DB5DB51D /* AuthManagerTests.swift in Sources */,
+				B6CD7B8DDAFBD7F05F29B8C6 /* AuthMapperTests.swift in Sources */,
+				E40BE71EC32FC867F700DC7D /* AuthViewModelTests.swift in Sources */,
+				ECC7B3DF4ECCF0C169F926C2 /* BiometricAuthManagerTests.swift in Sources */,
+				DFA161097F54448F3606E4F4 /* ChatMessageMapperTests.swift in Sources */,
+				A6E9039247DC4A73D17DD09E /* ChatMessageModelTests.swift in Sources */,
+				FB1623A4889699FE2BCB3C4C /* ChatViewModelTests.swift in Sources */,
+				C1925432A455B5B9A664E262 /* DeepgramMessageDTOTests.swift in Sources */,
+				70138340EEEC83289A413EA2 /* DownloadFileUseCaseTests.swift in Sources */,
+				04DC8756C530779C225AE8E4 /* FileDTOTests.swift in Sources */,
+				B99E36C093DA02E389D6707F /* FileMapperTests.swift in Sources */,
+				A5A655088C7FC6EE0F5AA9B8 /* FilePickerViewModelTests.swift in Sources */,
+				8AFBF713036A6552D5EF92C3 /* FileTestFactory.swift in Sources */,
+				7223739E25D8C0FF202B37BB /* GetProjectsUseCaseTests.swift in Sources */,
+				E033ECD6FDB5F442243A5D54 /* HandleNotificationUseCaseTests.swift in Sources */,
+				CCABAE6C1D0350F09A27AE99 /* HomeViewModelTests.swift in Sources */,
+				00A429AD9984993125CFFE5F /* KeychainHelperTests.swift in Sources */,
+				9965E3E5B82695EC0BE4E9CF /* LoadChatHistoryUseCaseTests.swift in Sources */,
+				FE20ACD5165C00FA5E05D89D /* LoadScreenshotUseCaseTests.swift in Sources */,
+				F116E333753F605825908560 /* LoadSettingsUseCaseTests.swift in Sources */,
+				395D1A871FD58CBB420430A1 /* LoginUseCaseTests.swift in Sources */,
+				A8440D5A7E68DCC44E6EAFA9 /* MockApprovalRepository.swift in Sources */,
+				1D1157B17E827FDD41E0ABE1 /* MockAuthRepository.swift in Sources */,
+				A2ABE3A46A5D9EB3D516B95B /* MockChatRepository.swift in Sources */,
+				720586133405485A2876C53F /* MockFileRepository.swift in Sources */,
+				52D1314E80B9B3827504E91E /* MockNotificationRepository.swift in Sources */,
+				6F9955265FD9FA3E2AFCDE08 /* MockProgressRepository.swift in Sources */,
+				AA0C588BF79A91BBC6EC49D9 /* MockProjectRepository.swift in Sources */,
+				DCB3FF8BA26864D706D72195 /* MockScreenshotRepository.swift in Sources */,
+				82E1E1ED5AE6DD3A5BF0A669 /* MockSettingsRepository.swift in Sources */,
+				7421CD398BD04F2BDC04AA7E /* MockVoiceAudioPlayer.swift in Sources */,
+				30FA7696EA507B83ACF694B7 /* MockVoiceInputRepository.swift in Sources */,
+				50D6EE8F2DE87B5F96CA4FD5 /* MockVoiceOutputRepository.swift in Sources */,
+				FFF07533B53FC9F056179983 /* NotificationCategoryTests.swift in Sources */,
+				3E11FD135C45C3D984211CD4 /* NotificationMapperTests.swift in Sources */,
+				C1CC0EB0386F7B80DF0AD0D1 /* NotificationRouterTests.swift in Sources */,
+				5248F01C12D77D6B43AA7AA0 /* ObserveProgressUseCaseTests.swift in Sources */,
+				72E118C7BE74A861C487790B /* ProgressMapperTests.swift in Sources */,
+				09A8C98AF09920405C772997 /* ProgressModelTests.swift in Sources */,
+				FA5EA21A153E4070D5EC0479 /* ProgressRepositoryImplTests.swift in Sources */,
+				1EA2E5E7AFDEC784ACCBE7C8 /* ProgressTestFactory.swift in Sources */,
+				B7E953B959FAA27DA543C76D /* ProgressViewModelTests.swift in Sources */,
+				9C7F8E0EA6753D2F8D5E5CBC /* ProjectDetailViewModelTests.swift in Sources */,
+				F66535758ABA5F61656881A0 /* ProjectListViewModelTests.swift in Sources */,
+				C0C58F1F61426CA96DCEFADE /* ProjectMapperTests.swift in Sources */,
+				C98FDB7766795513AEEB1A75 /* ProjectStatusMapperTests.swift in Sources */,
+				F2C1C0B1F7E28C6CA820E9BC /* RFButtonTests.swift in Sources */,
+				246C5412E373E052423CDFE2 /* RFCardTests.swift in Sources */,
+				1E0E7D6B3EF5707969CD553F /* RFSpacingTests.swift in Sources */,
+				BB8F03022D41EA75F5C4B537 /* RFTextFieldTests.swift in Sources */,
+				0094D3ECB7DE3EDD40CFCA6E /* RFTextTests.swift in Sources */,
+				6E57A7C79B809272E78BBBFA /* RFTypographyTests.swift in Sources */,
+				68E7170F1D4A0B0511B86304 /* RafRafTests.swift in Sources */,
+				8E3780EE4B737661383464D4 /* RefreshTokenUseCaseTests.swift in Sources */,
+				F96D453993430F1AE425A673 /* RegisterDeviceTokenUseCaseTests.swift in Sources */,
+				CEB59EDD52E3E003144110BE /* SaveSettingsUseCaseTests.swift in Sources */,
+				088F92D188D922C2A6858E32 /* ScreenshotDTOTests.swift in Sources */,
+				4425A8A8C5B2A44E05602D67 /* ScreenshotMapperTests.swift in Sources */,
+				33352F715A9A777C09D806C7 /* ScreenshotModelTests.swift in Sources */,
+				47CCE3B260AF692FAA7606CA /* ScreenshotTestFactory.swift in Sources */,
+				23771195AC45B562E87C90EE /* ScreenshotViewerViewModelTests.swift in Sources */,
+				1E7221F3B2129D72AC349A25 /* SendMessageUseCaseTests.swift in Sources */,
+				4F574BB1C3C518704E93FE30 /* SettingsRepositoryImplTests.swift in Sources */,
+				DAF965C1CCB995AD0E832DA5 /* SettingsTestFactory.swift in Sources */,
+				E9D28408EC9CAA36465ACCDE /* SettingsViewModelTests.swift in Sources */,
+				A89AC680DE7C152C2CD4F284 /* StartVoiceRecordingUseCaseTests.swift in Sources */,
+				BB804E5FCC4487FA6F17BBBE /* SubmitApprovalDecisionUseCaseTests.swift in Sources */,
+				A010C15DE98A70A25BCFAAE9 /* SupportedFileTypeTests.swift in Sources */,
+				951CC76E459C070DBE14DCD7 /* SynthesizeSpeechUseCaseTests.swift in Sources */,
+				4555097283E4374AA064D72F /* TTSAudioResultTests.swift in Sources */,
+				FC69316AA142DF6D1E44265B /* TTSMapperTests.swift in Sources */,
+				B12D2683360A1BEE9F8C8B1B /* TTSRequestDTOTests.swift in Sources */,
+				CAEC989FDB183AA2D7865152 /* TTSRequestTests.swift in Sources */,
+				79E0E4D5882597439861B862 /* TTSVoiceTests.swift in Sources */,
+				74EBD4E5B6AC3883E755DFCA /* TranscriptionMapperTests.swift in Sources */,
+				77DE5777F39B36D8A2BACD7D /* VoiceInputStateTests.swift in Sources */,
+				A597B8CEA836DFF91363EE02 /* VoiceInputTestFactory.swift in Sources */,
+				13C90BACF6044E45AED79F36 /* VoiceInputViewModelTests.swift in Sources */,
+				E33D453E15C9E01E59278C0F /* VoiceLanguageTests.swift in Sources */,
+				CDFBB3177E574C6A3174F774 /* VoiceOutputStateTests.swift in Sources */,
+				05A157E836252BF2B965C678 /* VoiceOutputTestFactory.swift in Sources */,
+				8AB419F196184A4BC864ACB8 /* VoiceOutputViewModelTests.swift in Sources */,
+				6C042BE5A215488A786F817B /* WebSocketClientTests.swift in Sources */,
+				68717A8857753A2E89F89966 /* WebSocketConnectionManagerTests.swift in Sources */,
+				E03DDF57418D07DA468DE23C /* WebSocketMessageRouterTests.swift in Sources */,
+				683999A7AAA0173449BEE8BF /* WebSocketMessageTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		5C2EF136E49BC77606B66768 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2CC52146BD6CF99A70B8CFA3 /* RafRaf */;
+			targetProxy = F610CCABE0070928371DC439 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		3065478F73EFEC17071D2B11 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = app.rafraf.RafRafTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RafRaf.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RafRaf";
+			};
+			name = Release;
+		};
+		746BEB5D6B8A446999A93B35 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 0.1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		A755C2A2F447571398EF5B31 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = app.rafraf.RafRafTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RafRaf.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RafRaf";
+			};
+			name = Debug;
+		};
+		C3A21E0C1F4662525A469D61 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = RafRaf/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = app.rafraf.RafRaf;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E9F3A7F2A0DE43B341582B2F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 0.1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		EEB8D3871DB6CE75570C6526 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = RafRaf/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = app.rafraf.RafRaf;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7982111198C1AC0AFA36690A /* Build configuration list for PBXProject "RafRaf" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				746BEB5D6B8A446999A93B35 /* Debug */,
+				E9F3A7F2A0DE43B341582B2F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		CE4957F9EEAEF8B3536AB708 /* Build configuration list for PBXNativeTarget "RafRafTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A755C2A2F447571398EF5B31 /* Debug */,
+				3065478F73EFEC17071D2B11 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		F301B6F7C129BA404FFE08C0 /* Build configuration list for PBXNativeTarget "RafRaf" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C3A21E0C1F4662525A469D61 /* Debug */,
+				EEB8D3871DB6CE75570C6526 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		235A2FDE642AE94989E33D25 /* XCRemoteSwiftPackageReference "Nuke" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kean/Nuke.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.8.0;
+			};
+		};
+		9661151B4FBCF41DF1F308C3 /* XCRemoteSwiftPackageReference "Factory" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/hmlongco/Factory.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		6E10A0D15B0B7D188A64F34E /* Nuke */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 235A2FDE642AE94989E33D25 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = Nuke;
+		};
+		E1E2A2A56BA5D07346F09E34 /* NukeUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 235A2FDE642AE94989E33D25 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = NukeUI;
+		};
+		ECB3212567B4D6E2AE1748D8 /* Factory */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9661151B4FBCF41DF1F308C3 /* XCRemoteSwiftPackageReference "Factory" */;
+			productName = Factory;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 07E1E16FD89DE3C0B3FD36FA /* Project object */;
+}

--- a/apps/ios/RafRaf.xcodeproj/xcshareddata/xcschemes/RafRaf.xcscheme
+++ b/apps/ios/RafRaf.xcodeproj/xcshareddata/xcschemes/RafRaf.xcscheme
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2CC52146BD6CF99A70B8CFA3"
+               BuildableName = "RafRaf.app"
+               BlueprintName = "RafRaf"
+               ReferencedContainer = "container:RafRaf.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4CEBB5AE9DA5DDB2803DA0D0"
+               BuildableName = "RafRafTests.xctest"
+               BlueprintName = "RafRafTests"
+               ReferencedContainer = "container:RafRaf.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2CC52146BD6CF99A70B8CFA3"
+            BuildableName = "RafRaf.app"
+            BlueprintName = "RafRaf"
+            ReferencedContainer = "container:RafRaf.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4CEBB5AE9DA5DDB2803DA0D0"
+               BuildableName = "RafRafTests.xctest"
+               BlueprintName = "RafRafTests"
+               ReferencedContainer = "container:RafRaf.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2CC52146BD6CF99A70B8CFA3"
+            BuildableName = "RafRaf.app"
+            BlueprintName = "RafRaf"
+            ReferencedContainer = "container:RafRaf.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2CC52146BD6CF99A70B8CFA3"
+            BuildableName = "RafRaf.app"
+            BlueprintName = "RafRaf"
+            ReferencedContainer = "container:RafRaf.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/ios/RafRaf/Info.plist
+++ b/apps/ios/RafRaf/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>RafRaf sesli komut ve ses kaydi icin mikrofon erisimi gerektirir.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>RafRaf sesli komutlari metne donusturmek icin konusma tanima erisimi gerektirir.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>RafRaf dosya paylasimi icin kamera erisimi gerektirir.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>RafRaf dosya paylasimi icin fotograf kitapligina erisim gerektirir.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+		<string>audio</string>
+	</array>
+</dict>
+</plist>

--- a/apps/ios/RafRaf/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apps/ios/RafRaf/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/ios/RafRaf/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/apps/ios/RafRaf/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/ios/RafRaf/Resources/Assets.xcassets/Contents.json
+++ b/apps/ios/RafRaf/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -1,0 +1,85 @@
+name: RafRaf
+options:
+  bundleIdPrefix: app.rafraf
+  deploymentTarget:
+    iOS: "17.0"
+  xcodeVersion: "16.0"
+  generateEmptyDirectories: false
+  createIntermediateGroups: true
+  defaultConfig: Debug
+
+settings:
+  base:
+    SWIFT_VERSION: "6.0"
+    MARKETING_VERSION: "0.1.0"
+    CURRENT_PROJECT_VERSION: "1"
+    DEVELOPMENT_TEAM: ""
+    CODE_SIGN_IDENTITY: "-"
+    CODE_SIGN_STYLE: Automatic
+    SWIFT_STRICT_CONCURRENCY: complete
+
+packages:
+  Factory:
+    url: https://github.com/hmlongco/Factory.git
+    from: "2.4.0"
+  Nuke:
+    url: https://github.com/kean/Nuke.git
+    from: "12.8.0"
+
+targets:
+  RafRaf:
+    type: application
+    platform: iOS
+    sources:
+      - path: RafRaf
+        excludes:
+          - "**/*.xcstrings"
+          - "Resources/Assets.xcassets"
+    resources:
+      - path: RafRaf/Resources/Localizable.xcstrings
+      - path: RafRaf/Resources/Assets.xcassets
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: app.rafraf.RafRaf
+        INFOPLIST_FILE: RafRaf/Info.plist
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        GENERATE_INFOPLIST_FILE: false
+    dependencies:
+      - package: Factory
+      - package: Nuke
+        product: Nuke
+      - package: Nuke
+        product: NukeUI
+
+  RafRafTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: RafRafTests
+    dependencies:
+      - target: RafRaf
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: app.rafraf.RafRafTests
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/RafRaf.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RafRaf"
+        BUNDLE_LOADER: "$(TEST_HOST)"
+
+schemes:
+  RafRaf:
+    build:
+      targets:
+        RafRaf: all
+        RafRafTests: [test]
+    run:
+      config: Debug
+      simulateLocation: false
+    test:
+      config: Debug
+      targets:
+        - RafRafTests
+    profile:
+      config: Release
+    analyze:
+      config: Debug
+    archive:
+      config: Release


### PR DESCRIPTION
## Summary
- XcodeGen (`project.yml`) ile iOS uygulaması için `.xcodeproj` oluşturuldu
- `Info.plist` eklendi (mikrofon, kamera, fotoğraf kitaplığı, konuşma tanıma privacy key'leri + push/audio background modes)
- `Assets.xcassets` eklendi (AppIcon + AccentColor placeholder)
- Package.swift değiştirilmedi — mevcut SPM yapısıyla uyumlu

## Test plan
- [x] `xcodebuild build` — iPhone 16 Simulator (iOS 18.6) üzerinde BUILD SUCCEEDED
- [x] `xcodebuild test` — 618 test, 83 suite, hepsi geçti
- [x] `open RafRaf.xcodeproj` → Cmd+R ile simulator'da çalıştırılabilir

🤖 Generated with [Claude Code](https://claude.com/claude-code)