### PR TITLE
feat(backend): Migrate from Anthropic API to AWS Bedrock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,17 +26,17 @@ REDIS_URL=redis://localhost:6379/0
 MEM0_PORT=8070
 
 # -----------------------------------------------------------------------------
-# Claude API (AI reasoning + tool calling)
+# Claude API (opsiyonel — USE_BEDROCK=true ise gereksiz)
 # -----------------------------------------------------------------------------
 ANTHROPIC_API_KEY=
 
 # -----------------------------------------------------------------------------
-# Deepgram STT (speech-to-text)
+# Deepgram STT (speech-to-text — iOS client icin)
 # -----------------------------------------------------------------------------
 DEEPGRAM_API_KEY=
 
 # -----------------------------------------------------------------------------
-# OpenAI TTS (text-to-speech)
+# OpenAI (opsiyonel — USE_BEDROCK=true ise Titan Embed kullanilir)
 # -----------------------------------------------------------------------------
 OPENAI_API_KEY=
 
@@ -46,11 +46,17 @@ OPENAI_API_KEY=
 GITHUB_TOKEN=
 
 # -----------------------------------------------------------------------------
-# AWS (S3, CloudWatch)
+# AWS (S3, CloudWatch, Bedrock)
 # -----------------------------------------------------------------------------
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_S3_BUCKET=rafraf-dev
+AWS_REGION=eu-central-1
+
+# -----------------------------------------------------------------------------
+# Bedrock — true ise AWS credentials ile Claude + Titan Embed kullanilir
+# -----------------------------------------------------------------------------
+USE_BEDROCK=true
 
 # -----------------------------------------------------------------------------
 # JWT Authentication

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -43,6 +43,9 @@ class Settings(BaseSettings):
     aws_s3_bucket: str = ""
     aws_region: str = "eu-central-1"
 
+    # Bedrock
+    use_bedrock: bool = True
+
     # WebSocket
     ws_heartbeat_interval: int = 30
     ws_heartbeat_timeout: int = 10

--- a/apps/backend/app/orchestrator/agent.py
+++ b/apps/backend/app/orchestrator/agent.py
@@ -61,9 +61,18 @@ class OrchestratorAgent:
 
     def __init__(self, tool_registry: ToolRegistry) -> None:
         self._registry = tool_registry
-        self._client = anthropic.AsyncAnthropic(
-            api_key=get_settings().anthropic_api_key,
-        )
+        settings = get_settings()
+        self._client: anthropic.AsyncAnthropic | anthropic.AsyncAnthropicBedrock
+        if settings.use_bedrock:
+            self._client = anthropic.AsyncAnthropicBedrock(
+                aws_access_key=settings.aws_access_key_id,
+                aws_secret_key=settings.aws_secret_access_key,
+                aws_region=settings.aws_region,
+            )
+        else:
+            self._client = anthropic.AsyncAnthropic(
+                api_key=settings.anthropic_api_key,
+            )
         # Session-based conversation history
         self._conversations: dict[str, list[anthropic.types.MessageParam]] = {}
 

--- a/apps/backend/app/orchestrator/model_router.py
+++ b/apps/backend/app/orchestrator/model_router.py
@@ -20,6 +20,8 @@ from enum import StrEnum
 import structlog
 from pydantic import BaseModel, ConfigDict
 
+from app.core.config import get_settings
+
 logger: structlog.stdlib.BoundLogger = structlog.get_logger()
 
 
@@ -31,17 +33,39 @@ class ModelTier(StrEnum):
     OPUS = "opus"
 
 
-# Model identifiers for each tier
-MODEL_HAIKU: str = "claude-haiku-4-5-20251001"
-MODEL_SONNET: str = "claude-sonnet-4-5-20250929"
-MODEL_OPUS: str = "claude-opus-4-5-20250929"
+# Model identifiers — Direct Anthropic API
+_DIRECT_HAIKU: str = "claude-haiku-4-5-20251001"
+_DIRECT_SONNET: str = "claude-sonnet-4-5-20250929"
+_DIRECT_OPUS: str = "claude-opus-4-5-20250929"
+
+# Model identifiers — AWS Bedrock EU inference profiles
+_BEDROCK_HAIKU: str = "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+_BEDROCK_SONNET: str = "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+_BEDROCK_OPUS: str = "eu.anthropic.claude-opus-4-5-20251101-v1:0"
+
+
+def _get_model_ids() -> tuple[str, str, str]:
+    """Return (haiku, sonnet, opus) model IDs based on use_bedrock setting."""
+    if get_settings().use_bedrock:
+        return _BEDROCK_HAIKU, _BEDROCK_SONNET, _BEDROCK_OPUS
+    return _DIRECT_HAIKU, _DIRECT_SONNET, _DIRECT_OPUS
+
+
+# Public model identifiers (resolved at import time for backwards compat)
+MODEL_HAIKU, MODEL_SONNET, MODEL_OPUS = _get_model_ids()
+
+
+def _build_tier_map() -> dict[ModelTier, str]:
+    haiku, sonnet, opus = _get_model_ids()
+    return {
+        ModelTier.HAIKU: haiku,
+        ModelTier.SONNET: sonnet,
+        ModelTier.OPUS: opus,
+    }
+
 
 # Mapping from tier to model identifier
-_TIER_TO_MODEL: dict[ModelTier, str] = {
-    ModelTier.HAIKU: MODEL_HAIKU,
-    ModelTier.SONNET: MODEL_SONNET,
-    ModelTier.OPUS: MODEL_OPUS,
-}
+_TIER_TO_MODEL: dict[ModelTier, str] = _build_tier_map()
 
 # Fallback chain: if requested tier is unavailable, try the next one
 _FALLBACK_CHAIN: dict[ModelTier, list[ModelTier]] = {

--- a/apps/backend/app/services/cost_service.py
+++ b/apps/backend/app/services/cost_service.py
@@ -22,9 +22,14 @@ logger: structlog.stdlib.BoundLogger = structlog.get_logger()
 # Model pricing per 1M tokens (USD).
 # Values based on Anthropic published pricing as of 2025.
 _MODEL_PRICING: dict[str, dict[str, float]] = {
+    # Direct Anthropic API
     "claude-opus-4-5-20250929": {"input": 15.0, "output": 75.0},
     "claude-sonnet-4-5-20250929": {"input": 3.0, "output": 15.0},
     "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.0},
+    # AWS Bedrock EU inference profiles
+    "eu.anthropic.claude-opus-4-5-20251101-v1:0": {"input": 15.0, "output": 75.0},
+    "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {"input": 3.0, "output": 15.0},
+    "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {"input": 0.80, "output": 4.0},
 }
 
 # Fallback pricing for unknown models

--- a/apps/backend/app/services/memory_service.py
+++ b/apps/backend/app/services/memory_service.py
@@ -67,6 +67,40 @@ class MemoryService:
             from mem0 import Memory
 
             settings = get_settings()
+
+            if settings.use_bedrock:
+                embedder_config: dict[str, object] = {
+                    "provider": "aws_bedrock",
+                    "config": {
+                        "model": "amazon.titan-embed-text-v2:0",
+                    },
+                }
+                llm_config: dict[str, object] = {
+                    "provider": "aws_bedrock",
+                    "config": {
+                        "model": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+                        "temperature": 0.1,
+                        "max_tokens": 1000,
+                    },
+                }
+                embedding_dims = 1024  # Titan Embed V2
+            else:
+                embedder_config = {
+                    "provider": "openai",
+                    "config": {
+                        "model": "text-embedding-3-small",
+                        "api_key": settings.openai_api_key,
+                    },
+                }
+                llm_config = {
+                    "provider": "anthropic",
+                    "config": {
+                        "model": "claude-haiku-4-5-20251001",
+                        "api_key": settings.anthropic_api_key,
+                    },
+                }
+                embedding_dims = 1536  # OpenAI text-embedding-3-small
+
             config: dict[str, object] = {
                 "vector_store": {
                     "provider": "pgvector",
@@ -75,23 +109,11 @@ class MemoryService:
                             "postgresql+asyncpg://", "postgresql://"
                         ),
                         "collection_name": "memories",
-                        "embedding_model_dims": 1536,
+                        "embedding_model_dims": embedding_dims,
                     },
                 },
-                "embedder": {
-                    "provider": "openai",
-                    "config": {
-                        "model": "text-embedding-3-small",
-                        "api_key": settings.openai_api_key,
-                    },
-                },
-                "llm": {
-                    "provider": "anthropic",
-                    "config": {
-                        "model": "claude-haiku-4-5-20251001",
-                        "api_key": settings.anthropic_api_key,
-                    },
-                },
+                "embedder": embedder_config,
+                "llm": llm_config,
             }
             self._mem0_client = Memory.from_config(config)
             self._mem0_initialized = True

--- a/apps/backend/tests/unit/test_orchestrator/test_agent.py
+++ b/apps/backend/tests/unit/test_orchestrator/test_agent.py
@@ -97,6 +97,7 @@ class TestOrchestratorAgent:
         mock_settings: MagicMock,
     ) -> None:
         """Processing a text message should return an OrchestratorResponse."""
+        mock_settings.return_value.use_bedrock = False
         mock_settings.return_value.anthropic_api_key = "test-key"
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -128,6 +129,7 @@ class TestOrchestratorAgent:
         mock_settings: MagicMock,
     ) -> None:
         """Processing should execute tool calls and continue the loop."""
+        mock_settings.return_value.use_bedrock = False
         mock_settings.return_value.anthropic_api_key = "test-key"
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -162,6 +164,7 @@ class TestOrchestratorAgent:
         mock_settings: MagicMock,
     ) -> None:
         """Calling an unregistered tool should return an error result."""
+        mock_settings.return_value.use_bedrock = False
         mock_settings.return_value.anthropic_api_key = "test-key"
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -193,6 +196,7 @@ class TestOrchestratorAgent:
         mock_settings: MagicMock,
     ) -> None:
         """Progress callback should be called during tool execution."""
+        mock_settings.return_value.use_bedrock = False
         mock_settings.return_value.anthropic_api_key = "test-key"
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -225,6 +229,7 @@ class TestOrchestratorAgent:
         mock_settings: MagicMock,
     ) -> None:
         """Tool execution errors should be returned as error results."""
+        mock_settings.return_value.use_bedrock = False
         mock_settings.return_value.anthropic_api_key = "test-key"
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -263,6 +268,7 @@ class TestOrchestratorAgent:
         mock_settings: MagicMock,
     ) -> None:
         """Tools requiring approval should return an error result."""
+        mock_settings.return_value.use_bedrock = False
         mock_settings.return_value.anthropic_api_key = "test-key"
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -302,6 +308,7 @@ class TestOrchestratorAgent:
         mock_settings: MagicMock,
     ) -> None:
         """Clearing conversation should remove session history."""
+        mock_settings.return_value.use_bedrock = False
         mock_settings.return_value.anthropic_api_key = "test-key"
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -338,6 +345,7 @@ class TestOrchestratorAgent:
         """Rate limit errors should trigger retries."""
         import anthropic as anthropic_mod
 
+        mock_settings.return_value.use_bedrock = False
         mock_settings.return_value.anthropic_api_key = "test-key"
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -381,6 +389,7 @@ class TestOrchestratorAgent:
         """Exhausting all retries should raise ClaudeAPIError."""
         import anthropic as anthropic_mod
 
+        mock_settings.return_value.use_bedrock = False
         mock_settings.return_value.anthropic_api_key = "test-key"
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client

--- a/apps/backend/tests/unit/test_services/test_cost_service.py
+++ b/apps/backend/tests/unit/test_services/test_cost_service.py
@@ -455,6 +455,7 @@ class TestGetSupportedModels:
         """Opus model should be in the supported list."""
         models = CostService.get_supported_models()
         opus_models = [m for m in models if "opus" in str(m["model"])]
-        assert len(opus_models) == 1
-        assert opus_models[0]["input_price_per_1m"] == 15.0
-        assert opus_models[0]["output_price_per_1m"] == 75.0
+        assert len(opus_models) >= 1
+        for m in opus_models:
+            assert m["input_price_per_1m"] == 15.0
+            assert m["output_price_per_1m"] == 75.0

--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -34,7 +34,7 @@ services:
     restart: unless-stopped
 
   mem0:
-    image: mem0ai/mem0:latest
+    image: mem0/mem0-api-server:latest
     container_name: rafraf-mem0
     ports:
       - "${MEM0_PORT:-8070}:8080"


### PR DESCRIPTION
## Summary
- Switch Claude API calls from direct Anthropic SDK to AWS Bedrock (`AsyncAnthropicBedrock`), eliminating ANTHROPIC_API_KEY dependency
- Replace OpenAI embeddings with Amazon Titan Embed V2 in mem0, eliminating OPENAI_API_KEY dependency
- Add `USE_BEDROCK=true` config flag for easy toggle between Bedrock and direct API
- Fix mem0 Docker image name (`mem0ai/mem0` → `mem0/mem0-api-server`)
- Create S3 bucket `rafraf-dev` in eu-central-1

## Changed files
- `.env.example` — Bedrock config, AWS_REGION, updated comments
- `apps/backend/app/core/config.py` — `use_bedrock: bool` setting
- `apps/backend/app/orchestrator/agent.py` — Bedrock client initialization
- `apps/backend/app/orchestrator/model_router.py` — EU inference profile model IDs
- `apps/backend/app/services/cost_service.py` — Bedrock model pricing
- `apps/backend/app/services/memory_service.py` — Bedrock LLM + Titan embedder
- `infra/docker/docker-compose.dev.yml` — Corrected mem0 Docker image
- Tests updated for Bedrock compatibility

## Test plan
- [x] `ruff check app/` — all checks passed
- [x] `mypy app/` — 85 files, 0 errors
- [x] `pytest` — 965 tests passed, 0 failed
- [x] Docker services start correctly (postgres, redis, mem0)
- [ ] Manual: verify Bedrock API call from running backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)